### PR TITLE
Committing results of "go mod vendor" because it fixed my build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.14
 require (
 	collectd.org v0.3.0
 	github.com/json-iterator/go v1.1.9
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.5.1
 )


### PR DESCRIPTION
While doing docker builds in brew we saw this error:

```
2020-11-10 18:37:56,459 - atomic_reactor.plugins.imagebuilder - INFO - Complete!
2020-11-10 18:37:56,678 - atomic_reactor.plugins.imagebuilder - INFO - --> RUN mkdir -p $GOPATH/src/github.com/infrawatch/sg-core/_build
2020-11-10 18:37:56,764 - atomic_reactor.plugins.imagebuilder - INFO - --> WORKDIR $GOPATH/src/github.com/infrawatch/sg-core
2020-11-10 18:37:56,801 - atomic_reactor.plugins.imagebuilder - INFO - --> ADD src $GOPATH/src/github.com/infrawatch/sg-core
2020-11-10 18:37:57,037 - atomic_reactor.plugins.imagebuilder - INFO - --> RUN /usr/bin/go build -mod vendor -o ./_build/server cmd/server/server.go
2020-11-10 18:37:57,204 - atomic_reactor.plugins.imagebuilder - INFO - go: inconsistent vendoring in /tmp/go/src/github.com/infrawatch/sg-core:
2020-11-10 18:37:57,204 - atomic_reactor.plugins.imagebuilder - INFO - 	collectd.org@v0.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
2020-11-10 18:37:57,204 - atomic_reactor.plugins.imagebuilder - INFO - 	github.com/json-iterator/go@v1.1.9: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
2020-11-10 18:37:57,204 - atomic_reactor.plugins.imagebuilder - INFO - 	github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
2020-11-10 18:37:57,204 - atomic_reactor.plugins.imagebuilder - INFO - 	github.com/modern-go/reflect2@v1.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
2020-11-10 18:37:57,205 - atomic_reactor.plugins.imagebuilder - INFO - 	github.com/prometheus/client_golang@v1.5.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
2020-11-10 18:37:57,205 - atomic_reactor.plugins.imagebuilder - INFO -
2020-11-10 18:37:57,205 - atomic_reactor.plugins.imagebuilder - INFO - run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
2020-11-10 18:37:57,910 - atomic_reactor.plugins.imagebuilder - INFO - running '/usr/bin/go build -mod vendor -o ./_build/server cmd/server/server.go' failed with exit code 1
2020-11-10 18:37:57,912 - atomic_reactor.plugin - ERROR - Build step plugin imagebuilder failed: image build failed (rc=1): running '/usr/bin/go build -mod vendor -o ./_build/server cmd/server/server.go' failed with exit code 1
```

I checked out the code to try to reproduce, and got this error instead:
```
[csibbitt@laptop sg-core (master) ]$ git pull
Already up to date.
[csibbitt@laptop sg-core (master) ]$ git diff
[csibbitt@laptop sg-core (master) ]$ rm -Rf vendor ./_build/server
[csibbitt@laptop sg-core (master) ]$ go build -mod vendor -o ./_build/server cmd/server/server.go
build command-line-arguments: cannot load collectd.org/cdtime: open /home/csibbitt/cloudops/sg-core/vendor/collectd.org/cdtime: no such file or directory
```

My error was solved by running `go mod vendor` as suggested in the original error:
```
[csibbitt@laptop sg-core (master) ]$ go mod vendor
[csibbitt@laptop sg-core (master) ]$ git diff
diff --git a/go.mod b/go.mod
index 2b1aa2b..8a90281 100644
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.14
 require (
        collectd.org v0.3.0
        github.com/json-iterator/go v1.1.9
+       github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+       github.com/modern-go/reflect2 v1.0.1 // indirect
        github.com/prometheus/client_golang v1.5.1
 )
[csibbitt@laptop sg-core (master) ]$ go build -mod vendor -o ./_build/server cmd/server/server.go
[csibbitt@laptop sg-core (master) ]$ ./_build/server 
inet or unix subcommand is required!
usage: ./_build/server [options] <command> [options]
```

I have not re-tested this in brew, and have not done any additional work to understand exactly what this is doing to solve either problem.