### PR TITLE
Matching golang version in test script

### DIFF
--- a/build/test-framework/run_tests.sh
+++ b/build/test-framework/run_tests.sh
@@ -16,6 +16,14 @@ go get -u github.com/mattn/goveralls
 go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
+# Update to golang which matches version in ubi:8
+go get golang.org/dl/go1.14.7
+go1.14.7 download
+alias go=go1.14.7
+
+# Add test deps to vendor dir
+go mod vendor
+
 # run code validation tools
 echo " *** Running pre-commit code validation"
 echo " --- [TODO] Tests expected to fail currently. Changes required to pass all testing. Disable for now."

--- a/build/test-framework/run_tests.sh
+++ b/build/test-framework/run_tests.sh
@@ -16,9 +16,6 @@ go get -u github.com/mattn/goveralls
 go get -u golang.org/x/lint/golint
 go get -u honnef.co/go/tools/cmd/staticcheck
 
-# get vendor code
-go mod vendor
-
 # run code validation tools
 echo " *** Running pre-commit code validation"
 echo " --- [TODO] Tests expected to fail currently. Changes required to pass all testing. Disable for now."


### PR DESCRIPTION
Test script was running `go mod vendor` with golang 1.13 from the default Travis environment, with the source dir mounted as a volume. This removes the "explicit" tags in modules.txt [1], causing the build to fail with "	collectd.org@v0.3.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt" when it is later built for real with golang 1.14 [2]. This script should probably run tests using the same version of golang we will eventually build with.  I'm removing this line because we do the `go mod vendor` before committing now. 

[1] https://github.com/infrawatch/sg-core/blob/master/vendor/modules.txt#L2
[2] https://travis-ci.org/github/infrawatch/sg-core/builds/743489014#L1237