### PR TITLE
Use Super Linter in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,16 +4,19 @@ env:
 on: push
 
 jobs:
-  golangci:
-    name: Linting
+  super-lint:
+    name: Lint code base
     runs-on: ubuntu-20.04
+
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.33
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-framework:
     name: Base testing


### PR DESCRIPTION
The Super Linter does testing of all sorts of code in the code base and is able to
generally auto-detect things. The Golang linters include our existing use of golangci-lint
so this is effectively a superset upgrade over that.