### PR TITLE
Delete ES indices on startup if configured

### DIFF
--- a/plugins/application/elasticsearch/main.go
+++ b/plugins/application/elasticsearch/main.go
@@ -99,6 +99,18 @@ func (es *Elasticsearch) Run(ctx context.Context, done chan bool) {
 	es.logger.Metadata(logging.Metadata{"plugin": appname, "url": es.configuration.HostURL})
 	es.logger.Info("storing events to Elasticsearch.")
 
+	if es.configuration.ResetIndices != nil {
+		err := es.client.IndicesDelete(es.configuration.ResetIndices)
+		if err != nil {
+			es.logger.Metadata(logging.Metadata{"plugin": appname, "error": err})
+			es.logger.Error("failed removing indices")
+			done <- true
+			return
+		}
+		es.logger.Metadata(logging.Metadata{"plugin": appname, "indices": es.configuration.ResetIndices})
+		es.logger.Info("removed indices")
+	}
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/plugins/application/elasticsearch/pkg/lib/config.go
+++ b/plugins/application/elasticsearch/pkg/lib/config.go
@@ -2,15 +2,16 @@ package lib
 
 //AppConfig holds configuration for Elasticsearch client
 type AppConfig struct {
-	HostURL       string `yaml:"hostURL"`
-	UseTLS        bool   `yaml:"useTLS"`
-	TLSServerName string `yaml:"tlsServerName"`
-	TLSClientCert string `yaml:"tlsClientCert"`
-	TLSClientKey  string `yaml:"tlsClientKey"`
-	TLSCaCert     string `yaml:"tlsCaCert"`
-	UseBasicAuth  bool   `yaml:"useBasicAuth"`
-	User          string `yaml:"user"`
-	Password      string `yaml:"password"`
-	BufferSize    int    `yaml:"bufferSize"`
-	BulkIndex     bool   `yaml:"bulkIndex"`
+	HostURL       string   `yaml:"hostURL"`
+	UseTLS        bool     `yaml:"useTLS"`
+	TLSServerName string   `yaml:"tlsServerName"`
+	TLSClientCert string   `yaml:"tlsClientCert"`
+	TLSClientKey  string   `yaml:"tlsClientKey"`
+	TLSCaCert     string   `yaml:"tlsCaCert"`
+	UseBasicAuth  bool     `yaml:"useBasicAuth"`
+	User          string   `yaml:"user"`
+	Password      string   `yaml:"password"`
+	BufferSize    int      `yaml:"bufferSize"`
+	BulkIndex     bool     `yaml:"bulkIndex"`
+	ResetIndices  []string `yaml:"resetIndices"`
 }


### PR DESCRIPTION
Fix omission of the ability to clear elastic search indices on start up if configured