### PR TITLE
Use the current apputils and update loki plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-openapi/errors v0.20.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/infrawatch/apputils v0.0.0-20210325130739-482adc424cd9
+	github.com/infrawatch/apputils v0.0.0-20210621123139-68f3c7c25e4f
 	github.com/json-iterator/go v1.1.10
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/plugins/application/loki/main.go
+++ b/plugins/application/loki/main.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/infrawatch/apputils/connector"
+	"github.com/infrawatch/apputils/connector/loki"
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
 	"github.com/infrawatch/sg-core/pkg/config"
@@ -25,7 +25,7 @@ type LokiConfig struct {
 // Loki plugin for forwarding logs to loki
 type Loki struct {
 	config     *LokiConfig
-	client     *connector.LokiConnector
+	client     *loki.LokiConnector
 	logger     *logging.Logger
 	logChannel chan interface{}
 }
@@ -80,7 +80,7 @@ func (l *Loki) Config(c []byte) error {
 		return err
 	}
 
-	l.client, err = connector.CreateLokiConnector(l.logger,
+	l.client, err = loki.CreateLokiConnector(l.logger,
 		l.config.Connection,
 		l.config.MaxWaitTime,
 		l.config.BatchSize)

--- a/plugins/application/loki/main_test.go
+++ b/plugins/application/loki/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/infrawatch/apputils/connector"
+	"github.com/infrawatch/apputils/connector/loki"
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +23,7 @@ const (
 
 type lokiTestCase struct {
 	Log    data.Event
-	Result connector.LokiLog
+	Result loki.LokiLog
 }
 
 var (
@@ -47,7 +47,7 @@ var (
 				},
 				Message: "Supervising 0 threads of 0 processes of 0 users.",
 			},
-			Result: connector.LokiLog{
+			Result: loki.LokiLog{
 				LogMessage: "Supervising 0 threads of 0 processes of 0 users.",
 				Timestamp:  time.Duration(1617888342) * time.Second,
 				Labels: map[string]string{
@@ -81,7 +81,7 @@ var (
 				},
 				Message: "detected unhandled Python exception in 'interactive mode (python -c ...)'",
 			},
-			Result: connector.LokiLog{
+			Result: loki.LokiLog{
 				LogMessage: "detected unhandled Python exception in 'interactive mode (python -c ...)'",
 				Timestamp:  time.Duration(1620316105) * time.Second,
 				Labels: map[string]string{
@@ -115,7 +115,7 @@ var (
 				},
 				Message: "Christmas!",
 			},
-			Result: connector.LokiLog{
+			Result: loki.LokiLog{
 				LogMessage: "Christmas!",
 				Timestamp:  time.Duration(1640361600) * time.Second,
 				Labels: map[string]string{

--- a/plugins/application/loki/pkg/lib/loki.go
+++ b/plugins/application/loki/pkg/lib/loki.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/infrawatch/apputils/connector"
+	"github.com/infrawatch/apputils/connector/loki"
 	"github.com/infrawatch/apputils/misc"
 
 	"github.com/infrawatch/sg-core/pkg/data"
@@ -21,16 +21,16 @@ func createLabels(rawLabels map[string]interface{}) (map[string]string, error) {
 }
 
 // CreateLokiLog forms event to a structure suitable for storage in Loki
-func CreateLokiLog(log data.Event) (connector.LokiLog, error) {
+func CreateLokiLog(log data.Event) (loki.LokiLog, error) {
 	labels, err := createLabels(log.Labels)
 	if err != nil {
-		return connector.LokiLog{}, err
+		return loki.LokiLog{}, err
 	}
 
 	// correct severity value in labels
 	labels["severity"] = log.Severity.String()
 
-	output := connector.LokiLog{
+	output := loki.LokiLog{
 		LogMessage: log.Message,
 		Timestamp:  time.Duration(log.Time) * time.Second,
 		Labels:     labels,


### PR DESCRIPTION
This PR makes sg-core use the most recent version of apputils and does all the required changes to the Loki plugin, which is the only one affected by the changes in apputils. Thanks to this we should be able to run the Loki plugin inside the sg-core containers. (Currently it fails, because it unsuccessfully tries to find libproton.so, even though it actually doesn't need it).