### PR TITLE
Fix concurrent conflicts in elasticsearch (#53)

### DIFF
--- a/plugins/application/elasticsearch/main_test.go
+++ b/plugins/application/elasticsearch/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/infrawatch/apputils/logging"
+	"github.com/infrawatch/sg-core/pkg/concurrent"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -232,7 +233,7 @@ func TestElasticsearchApp(t *testing.T) {
 		results := make(chan esIndex, len(eventCases))
 		app := &Elasticsearch{
 			logger: logger,
-			buffer: make(map[string][]string),
+			buffer: concurrent.NewMap(),
 			dump:   results,
 		}
 		err := app.Config([]byte(testConf))
@@ -254,7 +255,7 @@ func TestElasticsearchApp(t *testing.T) {
 		results := make(chan esIndex, len(logCases))
 		app := &Elasticsearch{
 			logger: logger,
-			buffer: make(map[string][]string),
+			buffer: concurrent.NewMap(),
 			dump:   results,
 		}
 		err := app.Config([]byte(testConf))


### PR DESCRIPTION
This patch makes use of concurrent package to fix conflicting writes/reads
to/from ES buffer when bulk index is configured

Cherry picked from commit e61141ab8d2590a7b91d18cd494321af763507bd
