### PR TITLE
Allow to listen on multiple sockets at once

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,19 +73,19 @@ func main() {
 	manager.SetPluginDir(configuration.PluginDir)
 
 	for _, tConfig := range configuration.Transports {
-		err = manager.InitTransport(tConfig.Name, tConfig.Config)
+		tName, err := manager.InitTransport(tConfig.Name, tConfig.Config)
 		if err != nil {
 			logger.Metadata(logging.Metadata{"transport": tConfig.Name, "error": err})
 			logger.Error("failed configuring transport")
 			continue
 		}
-		err = manager.SetTransportHandlers(tConfig.Name, tConfig.Handlers)
+		err = manager.SetTransportHandlers(tName, tConfig.Handlers)
 		if err != nil {
-			logger.Metadata(logging.Metadata{"transport": tConfig.Name, "error": err})
+			logger.Metadata(logging.Metadata{"transport": tName, "error": err})
 			logger.Error("transport handlers failed to load")
 			continue
 		}
-		logger.Metadata(logging.Metadata{"transport": tConfig.Name})
+		logger.Metadata(logging.Metadata{"transport": tName})
 		logger.Info("loaded transport")
 	}
 

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -7,6 +7,8 @@ import (
 	"plugin"
 	"strings"
 	"sync"
+	"strconv"
+	"math/rand"
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
@@ -50,29 +52,30 @@ func SetLogger(l *logging.Logger) {
 }
 
 // InitTransport load tranpsort binary and initialize with config
-func InitTransport(name string, config interface{}) error {
+func InitTransport(name string, config interface{}) (string, error) {
 	n, err := initPlugin(name)
 	if err != nil {
-		return errors.Wrap(err, "failed initializing transport")
+		return "", errors.Wrap(err, "failed initializing transport")
 	}
 
 	new, ok := n.(func(*logging.Logger) transport.Transport)
 	if !ok {
-		return fmt.Errorf("plugin %s constructor 'New' did not return type 'transport.Transport'", name)
+		return "", fmt.Errorf("plugin %s constructor 'New' did not return type 'transport.Transport'", name)
 	}
 
-	transports[name] = new(logger)
+	nam := strconv.Itoa(rand.Intn(10000))
+	transports[nam] = new(logger)
 
 	c, err := yaml.Marshal(config)
 	if err != nil {
-		return errors.Wrapf(err, "failed parsing transport config for '%s'", name)
+		return "", errors.Wrapf(err, "failed parsing transport config for '%s'", name)
 	}
 
-	err = transports[name].Config(c)
+	err = transports[nam].Config(c)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return nam, nil
 }
 
 // InitApplication initialize application plugin with configuration

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"plugin"
+	"strconv"
 	"strings"
 	"sync"
-	"strconv"
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"strconv"
-	"math/rand"
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
@@ -63,19 +62,21 @@ func InitTransport(name string, config interface{}) (string, error) {
 		return "", fmt.Errorf("plugin %s constructor 'New' did not return type 'transport.Transport'", name)
 	}
 
-	nam := strconv.Itoa(rand.Intn(10000))
-	transports[nam] = new(logger)
+	// Append the current length of transports
+	// to make each name unique
+	uniqueName := name + strconv.Itoa(len(transports))
+	transports[uniqueName] = new(logger)
 
 	c, err := yaml.Marshal(config)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed parsing transport config for '%s'", name)
 	}
 
-	err = transports[nam].Config(c)
+	err = transports[uniqueName].Config(c)
 	if err != nil {
 		return "", err
 	}
-	return nam, nil
+	return uniqueName, nil
 }
 
 // InitApplication initialize application plugin with configuration

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,28 @@
+pluginDir: /tmp/plugins
+logLevel: debug
+transports:
+    - name: socket
+      config:
+          path: "/tmp/smartgateway"
+      handlers:
+      - name: logs
+        config:
+            timestampField: "@timestamp"
+            messageField: "message"
+            severityField: "severity"
+            hostnameField: "host"
+    - name: socket
+      config:
+          path: "/tmp/logs"
+      handlers:
+      - name: logs
+        config:
+            timestampField: "@timestamp"
+            messageField: "message"
+            severityField: "severity"
+            hostnameField: "host"
+applications: 
+  - name: loki
+    config:
+        connection: "http://localhost:3100"
+        maxwaittime: 5s

--- a/docs/multiple-socket-plugins.md
+++ b/docs/multiple-socket-plugins.md
@@ -1,0 +1,33 @@
+# Multiple socket plugins
+To run sg-core with multiple socket (or other - untested) plugins, create a configuration similar to the following:
+```
+transports:
+    - name: socket
+      config:
+          path: "/tmp/smartgateway"
+      handlers:
+      - name: logs
+        config:
+            timestampField: "@timestamp"
+            messageField: "message"
+            severityField: "severity"
+            hostnameField: "host"
+    - name: socket
+      config:
+          path: "/tmp/logs"
+      handlers:
+      - name: logs
+        config:
+            timestampField: "@timestamp"
+            messageField: "message"
+            severityField: "severity"
+            hostnameField: "host"
+```
+This will start 2 socket plugins in parallel, each listening on a different socket. Possible use case for this setup is
+when running multiple sg-bridges, each listening on a different amqp address like this:
+```
+./bridge --amqp_url=amqp://127.0.0.1:5672/collectd --gw_unix=/tmp/smartgateway
+```
+```
+./bridge --amqp_url=amqp://127.0.0.1:5672/logs --gw_unix=/tmp/logs
+```


### PR DESCRIPTION
This PR implements unique names for transport plugins, which allows us to run multiple plugins of the same type (for example 2 socket transport plugins). It also adds some notes for this in the docs/ folder.

Solves #12.