### PR TITLE
Separate plugin for handling sensubility events. Store events as metrics in Prometheus rather than Elasticsearch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,25 +1,26 @@
 module github.com/infrawatch/sg-core
 
-go 1.14
+go 1.13
 
 require (
 	collectd.org v0.5.0
-	github.com/elastic/go-elasticsearch/v7 v7.11.0
+	github.com/elastic/go-elasticsearch/v7 v7.13.1
 	github.com/go-openapi/errors v0.20.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/infrawatch/apputils v0.0.0-20210325130739-482adc424cd9
-	github.com/json-iterator/go v1.1.10
+	github.com/json-iterator/go v1.1.11
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.9.0
-	github.com/stretchr/testify v1.7.0
-	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/common v0.29.0 // indirect
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	gopkg.in/go-playground/validator.v9 v9.31.0
-	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/infrawatch/sg-core
 
-go 1.13
+go 1.15
 
 require (
 	collectd.org v0.5.0
-	github.com/elastic/go-elasticsearch/v7 v7.13.1
+	github.com/elastic/go-elasticsearch/v7 v7.10.0
 	github.com/go-openapi/errors v0.20.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/pkg/lib/time.go
+++ b/pkg/lib/time.go
@@ -1,0 +1,19 @@
+package lib
+
+import "time"
+
+var (
+	isoTimeLayout = "2006-01-02 15:04:05.999999"
+	rFC3339       = "2006-01-02T15:04:05.999999"
+)
+
+// EpochFromFormat get epoch time from one of select time string formats
+func EpochFromFormat(ts string) int64 {
+	for _, layout := range []string{rFC3339, time.RFC3339, time.RFC3339Nano, time.ANSIC, isoTimeLayout} {
+		stamp, err := time.Parse(layout, ts)
+		if err == nil {
+			return stamp.Unix()
+		}
+	}
+	return 0
+}

--- a/plugins/handler/sensubility-metrics/main.go
+++ b/plugins/handler/sensubility-metrics/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/infrawatch/sg-core/pkg/bus"
+	jsoniter "github.com/json-iterator/go"
+)
+
+var (
+	json = jsoniter.ConfigCompatibleWithStandardLibrary
+)
+
+type ErrMissingFields struct {
+	fields []string
+}
+
+func (eMF *ErrMissingFields) Error() string {
+	fieldsFormatted := strings.Join(eMF.fields, ", ")
+	return fmt.Sprintf("missing fields in received data (%s)", fieldsFormatted)
+}
+
+func (eMF *ErrMissingFields) addMissingField(f string) {
+	eMF.fields = append(eMF.fields, f)
+}
+
+type sensubilityMetrics struct{}
+
+func (sm *sensubilityMetrics) Run(ctx context.Context, mpf bus.MetricPublishFunc, epf bus.EventPublishFunc) {
+
+}
+
+func (sm *sensubilityMetrics) Handle(blob []byte, reportErrors bool, mpf bus.MetricPublishFunc, epf bus.EventPublishFunc) error {
+	data := new(map[string]interface{})
+	err := json.Unmarshal(blob, &data)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(blob))
+
+	return nil
+}
+
+func (sm *sensubilityMetrics) Identify() string {
+	return "sensubility-metrics"
+}
+
+func (sm *sensubilityMetrics) Config(blob []byte) error {
+	return nil
+}

--- a/plugins/handler/sensubility-metrics/main.go
+++ b/plugins/handler/sensubility-metrics/main.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	json       = jsoniter.ConfigCompatibleWithStandardLibrary
-	metricName = "container_health_status"
+	metricName = "sensubility_container_health_status"
 )
 
 type sensubilityMetrics struct {

--- a/plugins/handler/sensubility-metrics/main.go
+++ b/plugins/handler/sensubility-metrics/main.go
@@ -114,7 +114,7 @@ func (sm *sensubilityMetrics) Handle(blob []byte, reportErrors bool, mpf bus.Met
 			data.GAUGE,
 			time.Second*time.Duration(sm.configuration.MetricInterval),
 			output.Healthy,
-			[]string{"container", "host"},
+			[]string{"process", "host"},
 			[]string{output.Service, sensuMsg.Labels.Client},
 		)
 	}

--- a/plugins/handler/sensubility-metrics/main.go
+++ b/plugins/handler/sensubility-metrics/main.go
@@ -107,7 +107,7 @@ func (sm *sensubilityMetrics) Handle(blob []byte, reportErrors bool, mpf bus.Met
 			data.GAUGE,
 			time.Second*10, // TODO: figure out what a good interval is, or make configure-able
 			output.Healthy,
-			[]string{"service", "host"},
+			[]string{"container", "host"},
 			[]string{output.Service, sensuMsg.Labels.Client},
 		)
 	}

--- a/plugins/handler/sensubility-metrics/main.go
+++ b/plugins/handler/sensubility-metrics/main.go
@@ -3,44 +3,114 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
+	"time"
 
 	"github.com/infrawatch/sg-core/pkg/bus"
+	"github.com/infrawatch/sg-core/pkg/data"
+	"github.com/infrawatch/sg-core/pkg/handler"
+	"github.com/infrawatch/sg-core/plugins/handler/events/pkg/lib"
+	"github.com/infrawatch/sg-core/plugins/handler/sensubility-metrics/pkg/sensu"
 	jsoniter "github.com/json-iterator/go"
 )
 
 var (
-	json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json       = jsoniter.ConfigCompatibleWithStandardLibrary
+	metricName = "container_health_status"
 )
 
-type ErrMissingFields struct {
-	fields []string
+type sensubilityMetrics struct {
+	totalMetricsDecoded   int64
+	totalDecodeErrors     int64
+	totalMessagesReceived int64
 }
-
-func (eMF *ErrMissingFields) Error() string {
-	fieldsFormatted := strings.Join(eMF.fields, ", ")
-	return fmt.Sprintf("missing fields in received data (%s)", fieldsFormatted)
-}
-
-func (eMF *ErrMissingFields) addMissingField(f string) {
-	eMF.fields = append(eMF.fields, f)
-}
-
-type sensubilityMetrics struct{}
 
 func (sm *sensubilityMetrics) Run(ctx context.Context, mpf bus.MetricPublishFunc, epf bus.EventPublishFunc) {
-
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+			mpf(
+				"sg_total_sensubility_metric_decode_count",
+				0,
+				data.COUNTER,
+				0,
+				float64(sm.totalMetricsDecoded),
+				[]string{"source"},
+				[]string{"SG"},
+			)
+			mpf(
+				"sg_total_sensubility_metric_decode_error_count",
+				0,
+				data.COUNTER,
+				0,
+				float64(sm.totalDecodeErrors),
+				[]string{"source"},
+				[]string{"SG"},
+			)
+			mpf(
+				"sg_total_sensubility_msg_received_count",
+				0,
+				data.COUNTER,
+				0,
+				float64(sm.totalMessagesReceived),
+				[]string{"source"},
+				[]string{"SG"},
+			)
+		}
+	}
 }
 
 func (sm *sensubilityMetrics) Handle(blob []byte, reportErrors bool, mpf bus.MetricPublishFunc, epf bus.EventPublishFunc) error {
-	data := new(map[string]interface{})
-	err := json.Unmarshal(blob, &data)
+	sm.totalMessagesReceived++
+	sensuMsg := sensu.Message{}
+	err := json.Unmarshal(blob, &sensuMsg)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(blob))
+	if !sensu.IsMsgValid(sensuMsg) {
+		sm.totalDecodeErrors++
+		err := sensu.BuildMsgErr(sensuMsg)
+		if reportErrors {
+			sm.publishErrEvent(err, epf)
+		}
+		return err
+	}
 
+	outputs := sensu.HealthCheckOutput{}
+	err = json.Unmarshal([]byte(sensuMsg.Annotations.Output), &outputs)
+	if err != nil {
+		return err
+	}
+
+	if !sensu.IsOutputValid(outputs) {
+		sm.totalDecodeErrors++
+		err := sensu.BuildOutputsErr(outputs)
+		if reportErrors {
+			sm.publishErrEvent(err, epf)
+		}
+		sm.totalDecodeErrors += int64(len(err.(*sensu.ErrMissingFields).Fields))
+		return err
+	}
+
+	epoc := lib.EpochFromFormat(sensuMsg.StartsAt)
+	if epoc == 0 {
+		return fmt.Errorf("failed determining epoch time from timestamp '%s'", sensuMsg.StartsAt)
+	}
+
+	for _, output := range outputs {
+		sm.totalMetricsDecoded++
+		mpf(
+			metricName,
+			float64(epoc),
+			data.GAUGE,
+			time.Second*10, // TODO: figure out what a good interval is, or make configure-able
+			output.Healthy,
+			[]string{"service", "host"},
+			[]string{output.Service, sensuMsg.Labels.Client},
+		)
+	}
 	return nil
 }
 
@@ -50,4 +120,24 @@ func (sm *sensubilityMetrics) Identify() string {
 
 func (sm *sensubilityMetrics) Config(blob []byte) error {
 	return nil
+}
+
+func New() handler.Handler {
+	return &sensubilityMetrics{}
+}
+
+func (sm *sensubilityMetrics) publishErrEvent(err error, epf bus.EventPublishFunc) {
+	epf(data.Event{
+		Index:    sm.Identify(),
+		Type:     data.ERROR,
+		Severity: data.CRITICAL,
+		Time:     0.0,
+		Labels: map[string]interface{}{
+			"error":   err.Error(),
+			"message": "failed to parse event - disregarding",
+		},
+		Annotations: map[string]interface{}{
+			"description": "internal smartgateway sensubility handler error",
+		},
+	})
 }

--- a/plugins/handler/sensubility-metrics/main_test.go
+++ b/plugins/handler/sensubility-metrics/main_test.go
@@ -35,16 +35,30 @@ func nilEPFunc(data.Event) {
 
 func TestConfiguration(t *testing.T) {
 	plug := sensubilityMetrics{}
-	configuration := "metricInterval: 50"
 
-	err := plug.Config([]byte(configuration))
-	if err != nil {
-		t.Error(err)
-	}
+	t.Run("default config", func(t *testing.T) {
+		err := plug.Config([]byte(""))
+		if err != nil {
+			t.Error(err)
+		}
 
-	if plug.configuration.MetricInterval != 50 {
-		t.Errorf("loading configuration failed - expected metricInterval: 50, got %d", plug.configuration.MetricInterval)
-	}
+		if plug.configuration.MetricInterval != 10 {
+			t.Errorf("default metricInterval should be 10, got %d", plug.configuration.MetricInterval)
+		}
+	})
+
+	t.Run("adjusted", func(t *testing.T) {
+		configuration := "metricInterval: 50"
+
+		err := plug.Config([]byte(configuration))
+		if err != nil {
+			t.Error(err)
+		}
+
+		if plug.configuration.MetricInterval != 50 {
+			t.Errorf("loading configuration failed - expected metricInterval: 50, got %d", plug.configuration.MetricInterval)
+		}
+	})
 }
 
 func TestSensuMetricHandling(t *testing.T) {

--- a/plugins/handler/sensubility-metrics/main_test.go
+++ b/plugins/handler/sensubility-metrics/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -63,6 +62,10 @@ func TestConfiguration(t *testing.T) {
 
 func TestSensuMetricHandling(t *testing.T) {
 	plug := sensubilityMetrics{}
+	err := plug.Config(nil)
+	if err != nil {
+		t.Error(err)
+	}
 
 	healthCheckRes := sensu.HealthCheckOutput{
 		{
@@ -99,21 +102,21 @@ func TestSensuMetricHandling(t *testing.T) {
 	t.Run("full metric generation", func(t *testing.T) {
 		correctResults := []data.Metric{
 			{
-				Name:      "container_health_status",
+				Name:      "sensubility_container_health_status",
 				Time:      1624992553.0,
 				Type:      data.GAUGE,
 				Interval:  time.Second * 10,
 				Value:     1,
-				LabelKeys: []string{"service", "host"},
+				LabelKeys: []string{"process", "host"},
 				LabelVals: []string{"glance", "controller-0.osp-cloudops-0"},
 			},
 			{
-				Name:      "container_health_status",
+				Name:      "sensubility_container_health_status",
 				Time:      1624992553.0,
 				Type:      data.GAUGE,
 				Interval:  time.Second * 10,
 				Value:     0,
-				LabelKeys: []string{"service", "host"},
+				LabelKeys: []string{"process", "host"},
 				LabelVals: []string{"nova", "controller-0.osp-cloudops-0"},
 			},
 		}
@@ -132,7 +135,6 @@ func TestSensuMetricHandling(t *testing.T) {
 			t.Error(err)
 		}
 
-		fmt.Println(string(inputBlob))
 		err = plug.Handle(
 			inputBlob,
 			false,
@@ -150,7 +152,7 @@ func TestSensuMetricHandling(t *testing.T) {
 	t.Run("metric name data model", func(t *testing.T) {
 		pubWrapper := mpFuncWrapper{
 			mFunc: func(m data.Metric) {
-				assert.Equal(t, "container_health_status", m.Name)
+				assert.Equal(t, "sensubility_container_health_status", m.Name)
 			},
 		}
 

--- a/plugins/handler/sensubility-metrics/main_test.go
+++ b/plugins/handler/sensubility-metrics/main_test.go
@@ -39,13 +39,13 @@ func TestSensuMetricHandling(t *testing.T) {
 	healthCheckRes := sensu.HealthCheckOutput{
 		{
 			Service:   "glance",
-			Container: 1235,
+			Container: "1235",
 			Status:    "healthy",
 			Healthy:   1,
 		},
 		{
 			Service:   "nova",
-			Container: 1235,
+			Container: "1235",
 			Status:    "healthy",
 			Healthy:   0,
 		},
@@ -104,6 +104,7 @@ func TestSensuMetricHandling(t *testing.T) {
 			t.Error(err)
 		}
 
+		fmt.Println(string(inputBlob))
 		err = plug.Handle(
 			inputBlob,
 			false,
@@ -233,7 +234,8 @@ func TestSensuMetricHandling(t *testing.T) {
 				},
 			}
 
-			input.Annotations.Output = "[{}]"
+			input.Annotations.Output = "[]"
+			input.StartsAt = "2021-06-29T18:49:13Z"
 			blob, err := json.Marshal(input)
 			if err != nil {
 				t.Error(err)
@@ -245,11 +247,9 @@ func TestSensuMetricHandling(t *testing.T) {
 				pubWrapper.MPFunc,
 				nilEPFunc,
 			)
-			eE, ok := err.(*sensu.ErrMissingFields)
-			assert.Equal(t, ok, true)
-			assert.Equal(t, eE.Fields, []string{
-				"annotations.output[0].service",
-			})
+			if err != nil {
+				t.Error(err)
+			}
 
 			input.Annotations.Output = "[{},{}]"
 			blob, err = json.Marshal(input)
@@ -262,9 +262,8 @@ func TestSensuMetricHandling(t *testing.T) {
 				pubWrapper.MPFunc,
 				nilEPFunc,
 			)
-			eE, ok = err.(*sensu.ErrMissingFields)
+			eE, ok := err.(*sensu.ErrMissingFields)
 			assert.Equal(t, ok, true)
-			fmt.Println(eE)
 			assert.Equal(t, eE.Fields, []string{
 				"annotations.output[0].service",
 				"annotations.output[1].service",

--- a/plugins/handler/sensubility-metrics/main_test.go
+++ b/plugins/handler/sensubility-metrics/main_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/infrawatch/sg-core/plugins/handler/sensubility-metrics/pkg/sensu"
+
+	"github.com/infrawatch/sg-core/pkg/data"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+// for convenience so that the whole metric publisher function signature
+// does not need to be written out for every test
+type mpFuncWrapper struct {
+	mFunc func(data.Metric)
+}
+
+func (pf *mpFuncWrapper) MPFunc(name string, timestamp float64, mt data.MetricType, interval time.Duration, val float64, labelKeys []string, labelVals []string) {
+	pf.mFunc(data.Metric{
+		Name:      name,
+		Time:      timestamp,
+		Type:      mt,
+		Interval:  interval,
+		Value:     val,
+		LabelKeys: labelKeys,
+		LabelVals: labelVals,
+	})
+}
+
+func nilEPFunc(data.Event) {
+
+}
+
+func TestSensuMetricHandling(t *testing.T) {
+	plug := sensubilityMetrics{}
+
+	healthCheckRes := sensu.HealthCheckOutput{
+		{
+			Service:   "glance",
+			Container: 1235,
+			Status:    "healthy",
+			Healthy:   1,
+		},
+		{
+			Service:   "nova",
+			Container: 1235,
+			Status:    "healthy",
+			Healthy:   0,
+		},
+	}
+
+	healthCheckResBlob, err := json.Marshal(healthCheckRes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	input := sensu.Message{
+		Labels: sensu.Labels{
+			Client:   "controller-0.osp-cloudops-0",
+			Check:    "check-container-health",
+			Severity: "FAILURE",
+		},
+		Annotations: sensu.Annotations{
+			Output: string(healthCheckResBlob),
+		},
+		StartsAt: "2021-06-29T18:49:13Z",
+	}
+
+	t.Run("correct metric generation", func(t *testing.T) {
+		correctResults := []data.Metric{
+			{
+				Name:      "check_container_health",
+				Time:      1625006953.0,
+				Type:      data.GAUGE,
+				Interval:  10,
+				Value:     1,
+				LabelKeys: []string{"service", "host"},
+				LabelVals: []string{"glance", "controller-0.osp-cloudops-0"},
+			},
+			{
+				Name:      "check_container_health",
+				Time:      1625006953.0,
+				Type:      data.GAUGE,
+				Interval:  10,
+				Value:     0,
+				LabelKeys: []string{"service", "host"},
+				LabelVals: []string{"nova", "controller-0.osp-cloudops-0"},
+			},
+		}
+		numPubCalls := 0
+		pubWrapper := mpFuncWrapper{
+			mFunc: func(m data.Metric) {
+				assert.Equal(t,
+					m,
+					correctResults[numPubCalls],
+				)
+				numPubCalls++
+			},
+		}
+		inputBlob, err := json.Marshal(input)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = plug.Handle(
+			inputBlob,
+			false,
+			pubWrapper.MPFunc,
+			nilEPFunc,
+		)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("metric name generation", func(t *testing.T) {
+		t.Run("missing name elements", func(t *testing.T) {
+			input.Labels.Check = ""
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			assert.NotEqual(t, err, nil)
+		})
+
+		t.Run("from check field", func(t *testing.T) {
+			input.Labels.Check = "check"
+
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(m data.Metric) {
+					assert.Equal(t, "check", m.Name)
+				},
+			}
+
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+
+		t.Run("sanitized name", func(t *testing.T) {
+			input.Labels.Check = "check.container?#$!-health"
+
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(m data.Metric) {
+					assert.Equal(t, "check_container_health", m.Name)
+				},
+			}
+
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	})
+
+	t.Run("error handling", func(t *testing.T) {
+		t.Run("corrupted JSON", func(t *testing.T) {
+			plug := sensubilityMetrics{}
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+
+			err := plug.Handle(
+				[]byte("{"),
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			assert.NotEqual(t, err, nil)
+		})
+
+		t.Run("missing field err generation", func(t *testing.T) {
+			plug := sensubilityMetrics{}
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+
+			err := plug.Handle(
+				[]byte("{}"),
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			eE, ok := err.(*ErrMissingFields)
+			assert.Equal(t, ok, true)
+			assert.Equal(t, eE.fields, []string{
+				"startsAt",
+				"labels.check",
+				"client",
+			})
+		})
+	})
+	t.Run("time", func(t *testing.T) {
+		t.Run("invalid time", func(t *testing.T) {
+			plug := sensubilityMetrics{}
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+			input.StartsAt = "asd4"
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			assert.NotEqual(t, err, nil)
+		})
+	})
+	t.Run("output field", func(t *testing.T) {
+		t.Run("incorrect format", func(t *testing.T) {
+			plug := sensubilityMetrics{}
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+			input.Annotations.Output = "asd4"
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			assert.NotEqual(t, err, nil)
+		})
+		t.Run("missing fields", func(t *testing.T) {
+			plug := sensubilityMetrics{}
+			pubWrapper := mpFuncWrapper{
+				mFunc: func(data.Metric) {
+					t.Error("publish func should not have been called")
+				},
+			}
+
+			input.Annotations.Output = "[{}]"
+			blob, err := json.Marshal(input)
+			if err != nil {
+				t.Error(err)
+			}
+
+			err = plug.Handle(
+				blob,
+				false,
+				pubWrapper.MPFunc,
+				nilEPFunc,
+			)
+			eE, ok := err.(*ErrMissingFields)
+			assert.Equal(t, ok, true)
+			assert.Equal(t, eE.fields, []string{
+				"annotations.output.service",
+				"annotations.output.healthy",
+			})
+		})
+	})
+}
+
+// test incorrect format in output field
+// test time field generation
+
+// Name      string
+// Time      float64
+// Type      MetricType
+// Interval  time.Duration
+// Value     float64
+// LabelKeys []string
+// LabelVals []string
+
+// Name:  labels.check (replace '-' with '_'), removing
+// Time: StartsAt
+// Type: data.GAUGE
+// Interval: ??
+// Value: annotations.status
+// LabelKeys: []string{'service', 'host'}
+// LabelVals: []string{'annotations.output.service','client'}
+
+// correct parsing

--- a/plugins/handler/sensubility-metrics/main_test.go
+++ b/plugins/handler/sensubility-metrics/main_test.go
@@ -33,6 +33,20 @@ func nilEPFunc(data.Event) {
 
 }
 
+func TestConfiguration(t *testing.T) {
+	plug := sensubilityMetrics{}
+	configuration := "metricInterval: 50"
+
+	err := plug.Config([]byte(configuration))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if plug.configuration.MetricInterval != 50 {
+		t.Errorf("loading configuration failed - expected metricInterval: 50, got %d", plug.configuration.MetricInterval)
+	}
+}
+
 func TestSensuMetricHandling(t *testing.T) {
 	plug := sensubilityMetrics{}
 

--- a/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
+++ b/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
@@ -1,5 +1,10 @@
 package sensu
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Message struct {
 	Labels      Labels
 	Annotations Annotations
@@ -27,5 +32,60 @@ type HealthCheckOutput []struct {
 	Service   string
 	Container int64
 	Status    string
-	Healthy   int64
+	Healthy   float64
+}
+
+type ErrMissingFields struct {
+	Fields []string
+}
+
+func (eMF *ErrMissingFields) Error() string {
+	fieldsFormatted := strings.Join(eMF.Fields, ", ")
+	return fmt.Sprintf("missing fields in received data (%s)", fieldsFormatted)
+}
+
+func (eMF *ErrMissingFields) addMissingField(f string) {
+	eMF.Fields = append(eMF.Fields, f)
+}
+
+func IsMsgValid(msg Message) bool {
+	if msg.StartsAt == "" {
+		return false
+	}
+
+	if msg.Labels.Client == "" {
+		return false
+	}
+	return true
+}
+
+func IsOutputValid(outputs HealthCheckOutput) bool {
+	for _, out := range outputs {
+		if out.Service == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func BuildMsgErr(msg Message) error {
+	err := &ErrMissingFields{}
+	if msg.StartsAt == "" {
+		err.addMissingField("startsAt")
+	}
+
+	if msg.Labels.Client == "" {
+		err.addMissingField("labels.client")
+	}
+	return err
+}
+
+func BuildOutputsErr(outputs HealthCheckOutput) error {
+	err := &ErrMissingFields{}
+	for index, out := range outputs {
+		if out.Service == "" {
+			err.addMissingField(fmt.Sprintf("annotations.output[%d].service", index))
+		}
+	}
+	return err
 }

--- a/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
+++ b/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
@@ -1,0 +1,31 @@
+package sensu
+
+type Message struct {
+	Labels      Labels
+	Annotations Annotations
+	StartsAt    string
+}
+
+type Labels struct {
+	Client   string
+	Check    string
+	Severity string
+}
+
+type Annotations struct {
+	Command  string
+	Issued   int64
+	Executed int64
+	Duration float64
+	Output   string
+	Status   int
+	Ves      string
+	StartsAt string
+}
+
+type HealthCheckOutput []struct {
+	Service   string
+	Container int64
+	Status    string
+	Healthy   int64
+}

--- a/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
+++ b/plugins/handler/sensubility-metrics/pkg/sensu/sensu.go
@@ -6,33 +6,32 @@ import (
 )
 
 type Message struct {
-	Labels      Labels
-	Annotations Annotations
-	StartsAt    string
+	Labels      Labels      `json:"labels"`
+	Annotations Annotations `json:"annotations"`
+	StartsAt    string      `json:"startsAt"`
 }
 
 type Labels struct {
-	Client   string
-	Check    string
-	Severity string
+	Client   string `json:"client"`
+	Check    string `json:"check"`
+	Severity string `json:"severity"`
 }
 
 type Annotations struct {
-	Command  string
-	Issued   int64
-	Executed int64
-	Duration float64
-	Output   string
-	Status   int
-	Ves      string
-	StartsAt string
+	Command  string  `json:"command"`
+	Issued   int64   `json:"issued"`
+	Executed int64   `json:"executed"`
+	Duration float64 `json:"duration"`
+	Output   string  `json:"output"`
+	Status   int     `json:"status"`
+	StartsAt string  `json:"startsAt"`
 }
 
 type HealthCheckOutput []struct {
-	Service   string
-	Container int64
-	Status    string
-	Healthy   float64
+	Service   string  `json:"service"`
+	Container string  `json:"container"`
+	Status    string  `json:"status"`
+	Healthy   float64 `json:"healthy"`
 }
 
 type ErrMissingFields struct {


### PR DESCRIPTION
Move storage of container health results as a status metric in Prometheus rather than an event in Elasticsearch. Moving this logic to a separate plugin means we can reduce the complexity of the code in the original events plugin so that it does not need to handle the edge case of sensubility events (I won't do that here).