### PR TITLE
Rename instance ID key from host to vm_instance

### DIFF
--- a/plugins/handler/ceilometer-metrics/main.go
+++ b/plugins/handler/ceilometer-metrics/main.go
@@ -214,7 +214,7 @@ func genLabels(m ceilometer.Metric, publisher string, cNameShards []string) ([]s
 	}
 
 	if m.ResourceMetadata.Host != "" {
-		labelKeys[index] = "host"
+		labelKeys[index] = "vm_instance"
 		labelVals[index] = m.ResourceMetadata.Host
 		index++
 	}

--- a/plugins/handler/ceilometer-metrics/messages/metric-tests.json
+++ b/plugins/handler/ceilometer-metrics/messages/metric-tests.json
@@ -19,7 +19,7 @@
             "project",
             "unit",
             "resource",
-            "host"
+            "vm_instance"
           ],
           "LabelVals": [
             "size",
@@ -46,7 +46,7 @@
             "project",
             "unit",
             "resource",
-            "host"
+            "vm_instance"
           ],
           "LabelVals": [
             "size",
@@ -73,7 +73,7 @@
             "project",
             "unit",
             "resource",
-            "host"
+            "vm_instance"
           ],
           "LabelVals": [
             "booting",
@@ -100,7 +100,7 @@
             "project",
             "unit",
             "resource",
-            "host"
+            "vm_instance"
           ],
           "LabelVals": [
             "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",
@@ -127,7 +127,7 @@
             "project",
             "unit",
             "resource",
-            "host"
+            "vm_instance"
           ],
           "LabelVals": [
             "d8bd99b6-6fd8-4c02-a2e3-efbf596df636",


### PR DESCRIPTION
Ceilometer metrics report vm instance id under the 'host' label. Rename this label to 'vm_instance' for clarity