### PR TITLE
Update apputils and fix dummy-logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/infrawatch/apputils v0.0.0-20210621123139-68f3c7c25e4f
+	github.com/infrawatch/apputils v0.0.0-20210809211320-3573b2937d14 // indirect
 	github.com/json-iterator/go v1.1.11
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/plugins/application/loki/main.go
+++ b/plugins/application/loki/main.go
@@ -83,7 +83,8 @@ func (l *Loki) Config(c []byte) error {
 	l.client, err = loki.CreateLokiConnector(l.logger,
 		l.config.Connection,
 		l.config.MaxWaitTime,
-		l.config.BatchSize)
+		l.config.BatchSize,
+		"fake")
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to Loki host")
 	}

--- a/plugins/transport/dummy-logs/main.go
+++ b/plugins/transport/dummy-logs/main.go
@@ -45,7 +45,6 @@ func (dl *DummyLogs) Run(ctx context.Context, wrFn transport.WriteFn, done chan 
 			case <-time.After(time.Second * 1):
 				time.Sleep(time.Second * 1)
 				msgBuffer = []byte(log)
-				msgBuffer = append(msgBuffer, 0)
 				wrFn(msgBuffer)
 			}
 		}


### PR DESCRIPTION
This PR makes sg-core use the newest version of apputils.
Summary of changes in apputils:

- Ability to specify Loki tenant
- Enhanced Loki error message
- Ability to get information about processes

Only affected part by these changes is the Loki plugin (the process info isn't used anywhere). I made the required change to make the Loki plugin compatible. The Loki plugin doesn't use tenants right now and "fake" is the default tenant for Loki.

I also fixed the dummy-logs transport plugin, which wasn't working.