### PR TITLE
Allow app plugin to be data producers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,7 +52,8 @@ linters:
     - typecheck
     # - unused
     - unconvert
-    - unparam
+    # NOTE: not all application plugins use ability to emit internal events through
+    #       passed bus function in it's constructor.
+    #- unparam
     - varcheck
     # - whitespace
-   

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -86,12 +86,12 @@ func InitApplication(name string, config interface{}) error {
 		return errors.Wrap(err, "failed initializing application plugin")
 	}
 
-	new, ok := n.(func(*logging.Logger) application.Application)
+	new, ok := n.(func(*logging.Logger, bus.MetricPublishFunc, bus.EventPublishFunc) application.Application)
 	if !ok {
 		return fmt.Errorf("plugin %s constructor 'New' did not return type 'application.Application'", name)
 	}
 
-	applications[name] = new(logger)
+	applications[name] = new(logger, metricBus.Publish, eventBus.Publish)
 
 	c, err := yaml.Marshal(config)
 	if err != nil {

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -86,12 +86,12 @@ func InitApplication(name string, config interface{}) error {
 		return errors.Wrap(err, "failed initializing application plugin")
 	}
 
-	new, ok := n.(func(*logging.Logger, bus.MetricPublishFunc, bus.EventPublishFunc) application.Application)
+	new, ok := n.(func(*logging.Logger, bus.EventPublishFunc) application.Application)
 	if !ok {
 		return fmt.Errorf("plugin %s constructor 'New' did not return type 'application.Application'", name)
 	}
 
-	applications[name] = new(logger, metricBus.Publish, eventBus.Publish)
+	applications[name] = new(logger, eventBus.Publish)
 
 	c, err := yaml.Marshal(config)
 	if err != nil {

--- a/plugins/application/alertmanager/main.go
+++ b/plugins/application/alertmanager/main.go
@@ -29,7 +29,7 @@ type AlertManager struct {
 }
 
 // New constructor
-func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
+func New(logger *logging.Logger, sendEvent bus.EventPublishFunc) application.Application {
 	return &AlertManager{
 		configuration: lib.AppConfig{
 			AlertManagerURL: "http://localhost",

--- a/plugins/application/alertmanager/main.go
+++ b/plugins/application/alertmanager/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/config"
 	"github.com/infrawatch/sg-core/pkg/data"
 
@@ -28,7 +29,7 @@ type AlertManager struct {
 }
 
 // New constructor
-func New(logger *logging.Logger) application.Application {
+func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
 	return &AlertManager{
 		configuration: lib.AppConfig{
 			AlertManagerURL: "http://localhost",

--- a/plugins/application/alertmanager/main_test.go
+++ b/plugins/application/alertmanager/main_test.go
@@ -178,7 +178,8 @@ func TestAlertmanagerApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
+		ebus := bus.EventBus{}
+		app := New(logger, ebus.Publish, bus.EventPublishFunc)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/alertmanager/main_test.go
+++ b/plugins/application/alertmanager/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/infrawatch/apputils/logging"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/infrawatch/sg-core/plugins/application/alertmanager/pkg/lib"
 	"github.com/stretchr/testify/assert"
@@ -177,7 +178,7 @@ func TestAlertmanagerApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger)
+		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/alertmanager/main_test.go
+++ b/plugins/application/alertmanager/main_test.go
@@ -179,7 +179,7 @@ func TestAlertmanagerApp(t *testing.T) {
 
 	t.Run("Test configuration", func(t *testing.T) {
 		ebus := bus.EventBus{}
-		app := New(logger, ebus.Publish, bus.EventPublishFunc)
+		app := New(logger, ebus.Publish)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/elasticsearch/main.go
+++ b/plugins/application/elasticsearch/main.go
@@ -58,7 +58,7 @@ type Elasticsearch struct {
 }
 
 // New constructor
-func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
+func New(logger *logging.Logger, sendEvent bus.EventPublishFunc) application.Application {
 	return &Elasticsearch{
 		logger: logger,
 		buffer: concurrent.NewMap(),

--- a/plugins/application/elasticsearch/main.go
+++ b/plugins/application/elasticsearch/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/apputils/misc"
 	"github.com/infrawatch/sg-core/pkg/application"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/config"
 	"github.com/infrawatch/sg-core/pkg/data"
 	jsoniter "github.com/json-iterator/go"
@@ -57,7 +58,7 @@ type Elasticsearch struct {
 }
 
 // New constructor
-func New(logger *logging.Logger) application.Application {
+func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
 	return &Elasticsearch{
 		logger: logger,
 		buffer: concurrent.NewMap(),

--- a/plugins/application/elasticsearch/main_test.go
+++ b/plugins/application/elasticsearch/main_test.go
@@ -225,7 +225,8 @@ func TestElasticsearchApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
+		ebus := bus.EventBus{}
+		app := New(logger, ebus.Publish)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/elasticsearch/main_test.go
+++ b/plugins/application/elasticsearch/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/infrawatch/apputils/logging"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/concurrent"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/stretchr/testify/assert"
@@ -224,7 +225,7 @@ func TestElasticsearchApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger)
+		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/loki/main.go
+++ b/plugins/application/loki/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/infrawatch/apputils/connector/loki"
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/config"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/pkg/errors"
@@ -31,7 +32,7 @@ type Loki struct {
 }
 
 // New constructor
-func New(logger *logging.Logger) application.Application {
+func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
 	return &Loki{
 		logger:     logger,
 		logChannel: make(chan interface{}, 100),

--- a/plugins/application/loki/main.go
+++ b/plugins/application/loki/main.go
@@ -32,7 +32,7 @@ type Loki struct {
 }
 
 // New constructor
-func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
+func New(logger *logging.Logger, sendEvent bus.EventPublishFunc) application.Application {
 	return &Loki{
 		logger:     logger,
 		logChannel: make(chan interface{}, 100),

--- a/plugins/application/loki/main_test.go
+++ b/plugins/application/loki/main_test.go
@@ -147,7 +147,8 @@ func TestLokiApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
+		ebus := bus.EventBus{}
+		app := New(logger, ebus.Publish)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/loki/main_test.go
+++ b/plugins/application/loki/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/infrawatch/apputils/connector/loki"
 	"github.com/infrawatch/apputils/logging"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,7 +147,7 @@ func TestLokiApp(t *testing.T) {
 	}()
 
 	t.Run("Test configuration", func(t *testing.T) {
-		app := New(logger)
+		app := New(logger, bus.MetricPublishFunc, bus.EventPublishFunc)
 		err := app.Config([]byte(testConf))
 		require.NoError(t, err)
 	})

--- a/plugins/application/print/main.go
+++ b/plugins/application/print/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/config"
 	"github.com/infrawatch/sg-core/pkg/data"
 )
@@ -37,7 +38,7 @@ type Print struct {
 }
 
 // New constructor
-func New(logger *logging.Logger) application.Application {
+func New(logger *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
 	return &Print{
 		configuration: configT{
 			MetricOutput: "/dev/stdout",

--- a/plugins/application/prometheus/main.go
+++ b/plugins/application/prometheus/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/application"
+	"github.com/infrawatch/sg-core/pkg/bus"
 	"github.com/infrawatch/sg-core/pkg/config"
 	"github.com/infrawatch/sg-core/pkg/data"
 	"github.com/prometheus/client_golang/prometheus"
@@ -233,7 +234,7 @@ type Prometheus struct {
 }
 
 // New constructor
-func New(l *logging.Logger) application.Application {
+func New(l *logging.Logger, sendMetric bus.MetricPublishFunc, sendEvent bus.EventPublishFunc) application.Application {
 	return &Prometheus{
 		configuration: configT{
 			Host:               "127.0.0.1",


### PR DESCRIPTION
Currently application plugins can only listen on internal buses.
This patch enables apps to also produce messages on internal metric
and event bus.

Partially-implements: STF-519