### PR TITLE
Increase reading buffer size on large messages 

### DIFF
--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -91,7 +91,12 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 	go func() {
 		for {
 			var buff bytes.Buffer
-			io.Copy(&buff, pc)
+			n, err := io.Copy(&buff, pc)
+			if err != nil {
+				s.logger.Errorf(err, "failed reading message")
+			} else {
+				s.logger.Debugf("read message of size %d bytes", n)
+			}
 			msg := buff.Bytes()
 
 			if s.conf.DumpMessages.Enabled {

--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	maxBufferSize  = 65535
+	maxBufferSize = 65535
 )
 
 var (

--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	initBufferSize = 65535
-	maxBufferSize  = 16384
+	initBufferSize = 16384
+	maxBufferSize  = 65535
 )
 
 var (

--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -103,7 +103,6 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 				done <- true
 				return
 			}
-			msg := buff.Bytes()
 
 			// whole buffer was used, so we are potentially handling larger message
 			// and have to increase buffer size
@@ -116,10 +115,11 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 				} else {
 					s.logger.Warnf("reading buffer insufficient, but cannot increase size anymore")
 				}
+				continue
 			}
 
 			if s.conf.DumpMessages.Enabled {
-				_, err := s.dumpBuf.Write(msg)
+				_, err := s.dumpBuf.Write(msgBuffer[:n])
 				if err != nil {
 					s.logger.Errorf(err, "writing to dump buffer")
 				}
@@ -130,8 +130,7 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 				s.dumpBuf.Flush()
 			}
 
-			w(msg)
-			buff.Reset()
+			w(msgBuffer[:n])
 			msgCount++
 		}
 	}(initBufferSize, maxBufferSize)

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -15,8 +15,6 @@ import (
 	"gopkg.in/go-playground/assert.v1"
 )
 
-const oldMaxBufferSize = 16384
-
 func TestSocketTransport(t *testing.T) {
 	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
 	require.NoError(t, err)
@@ -41,12 +39,12 @@ func TestSocketTransport(t *testing.T) {
 	}
 
 	t.Run("test large message transport", func(t *testing.T) {
-		msg := make([]byte, oldMaxBufferSize)
+		msg := make([]byte, initBufferSize)
 		addition := "wubba lubba dub dub"
-		for i := 0; i < oldMaxBufferSize; i++ {
+		for i := 0; i < initBufferSize; i++ {
 			msg[i] = byte('X')
 		}
-		msg[oldMaxBufferSize-1] = byte('$')
+		msg[initBufferSize-1] = byte('$')
 		msg = append(msg, []byte(addition)...)
 
 		// verify transport
@@ -55,7 +53,7 @@ func TestSocketTransport(t *testing.T) {
 		go trans.Run(ctx, func([]byte) {
 			wg.Add(1)
 			strmsg := string(msg)
-			assert.Equal(t, oldMaxBufferSize+len(addition), len(msg))     // we received whole message
+			assert.Equal(t, initBufferSize+len(addition), len(msg))       // we received whole message
 			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):]) // and the out-of-band part is correct
 			wg.Done()
 		}, make(chan bool))

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -55,8 +55,8 @@ func TestSocketTransport(t *testing.T) {
 		go trans.Run(ctx, func(mess []byte) {
 			wg.Add(1)
 			strmsg := string(mess)
-			assert.Equal(t, regularBuffSize+len(addition), len(strmsg))    // we received whole message
-			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):])  // and the out-of-band part is correct
+			assert.Equal(t, regularBuffSize+len(addition), len(strmsg))   // we received whole message
+			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):]) // and the out-of-band part is correct
 			wg.Done()
 		}, make(chan bool))
 

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/infrawatch/apputils/logging"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+const oldMaxBufferSize = 16384
+
+func TestSocketTransport(t *testing.T) {
+	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	logpath := path.Join(tmpdir, "test.log")
+	logger, err := logging.NewLogger(logging.DEBUG, logpath)
+	require.NoError(t, err)
+
+	sktpath := path.Join(tmpdir, "socket")
+	skt, err := os.OpenFile(sktpath, os.O_RDWR|os.O_CREATE, os.ModeSocket|os.ModePerm)
+	require.NoError(t, err)
+	defer skt.Close()
+
+	trans := Socket{
+		conf: configT{
+			Path: sktpath,
+		},
+		logger: &logWrapper{
+			l: logger,
+		},
+	}
+
+	t.Run("test large message transport", func(t *testing.T) {
+		msg := make([]byte, oldMaxBufferSize)
+		addition := "wubba lubba dub dub"
+		for i := 0; i < oldMaxBufferSize; i++ {
+			msg[i] = byte('X')
+		}
+		msg[oldMaxBufferSize-1] = byte('$')
+		msg = append(msg, []byte(addition)...)
+
+		// verify transport
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		go trans.Run(ctx, func([]byte) {
+			wg.Add(1)
+			strmsg := string(msg)
+			assert.Equal(t, oldMaxBufferSize+len(addition), len(msg))     // we received whole message
+			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):]) // and the out-of-band part is correct
+			wg.Done()
+		}, make(chan bool))
+
+		// wait for socket file to be created
+		for {
+			stat, err := os.Stat(sktpath)
+			require.NoError(t, err)
+			if stat.Mode()&os.ModeType == os.ModeSocket {
+				break
+			}
+			time.Sleep(250 * time.Millisecond)
+		}
+
+		// write to socket
+		wskt, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: sktpath, Net: "unixgram"})
+		require.NoError(t, err)
+		_, err = wskt.Write(msg)
+		require.NoError(t, err)
+
+		cancel()
+		wg.Wait()
+		wskt.Close()
+	})
+}

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/go-playground/assert.v1"
 )
 
+const regularBuffSize = 16384
+
 func TestSocketTransport(t *testing.T) {
 	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
 	require.NoError(t, err)
@@ -39,12 +41,12 @@ func TestSocketTransport(t *testing.T) {
 	}
 
 	t.Run("test large message transport", func(t *testing.T) {
-		msg := make([]byte, initBufferSize)
+		msg := make([]byte, regularBuffSize)
 		addition := "wubba lubba dub dub"
-		for i := 0; i < initBufferSize; i++ {
+		for i := 0; i < regularBuffSize; i++ {
 			msg[i] = byte('X')
 		}
-		msg[initBufferSize-1] = byte('$')
+		msg[regularBuffSize-1] = byte('$')
 		msg = append(msg, []byte(addition)...)
 
 		// verify transport
@@ -53,8 +55,8 @@ func TestSocketTransport(t *testing.T) {
 		go trans.Run(ctx, func(mess []byte) {
 			wg.Add(1)
 			strmsg := string(mess)
-			assert.Equal(t, initBufferSize+len(addition), len(strmsg))    // we received whole message
-			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):]) // and the out-of-band part is correct
+			assert.Equal(t, regularBuffSize+len(addition), len(strmsg))    // we received whole message
+			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):])  // and the out-of-band part is correct
 			wg.Done()
 		}, make(chan bool))
 

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -50,10 +50,10 @@ func TestSocketTransport(t *testing.T) {
 		// verify transport
 		ctx, cancel := context.WithCancel(context.Background())
 		wg := sync.WaitGroup{}
-		go trans.Run(ctx, func([]byte) {
+		go trans.Run(ctx, func(mess []byte) {
 			wg.Add(1)
-			strmsg := string(msg)
-			assert.Equal(t, initBufferSize+len(addition), len(msg))       // we received whole message
+			strmsg := string(mess)
+			assert.Equal(t, initBufferSize+len(addition), len(strmsg))    // we received whole message
 			assert.Equal(t, addition, strmsg[len(strmsg)-len(addition):]) // and the out-of-band part is correct
 			wg.Done()
 		}, make(chan bool))


### PR DESCRIPTION
When larger than MaxBufferSize messages are being sent, the whole message processing
is failing badly. This can easily happen when socket plugin is used in Ceilometer metrics
or events processing. This patch makes it to increase buffer size, when large message is detected.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2016460