### PR TITLE
Use latest tag on Dockerfile image references

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # --- build smart gateway ---
-FROM registry.access.redhat.com/ubi8 AS builder
+FROM registry.access.redhat.com/ubi8:latest AS builder
 ENV GOPATH=/go
 ENV D=/go/src/github.com/infrawatch/sg-core
 
@@ -13,7 +13,7 @@ RUN dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
 RUN PRODUCTION_BUILD=true ./build.sh
 
 # --- end build, create smart gateway layer ---
-FROM registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
 LABEL io.k8s.display-name="Smart Gateway" \
       io.k8s.description="A component of the Service Telemetry Framework on the server side that ingests data from AMQP 1.x and provides a metrics scrape endpoint for Prometheus, and forwards events to ElasticSearch" \


### PR DESCRIPTION
Prior to this change, I would receive this error when building sg-core

```
TASK [stf-run-ci : Create BuildConfig and ImageStream] ***************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc new-build -n \"service-telemetry\" --name sg-core --dockerfile - < ./working/sg-core/build/Dockerfile", "delta": "0:00:34.246661", "end": "2021-11-01 11:23:33.507520", "msg": "non-zero return code", "rc": 1, "start": "2021-11-01 11:22:59.260859", "stderr": "error: can't lookup images: Timeout: request did not complete within requested timeout context deadline exceeded\nerror: unable to locate any images in image streams, local docker images with name \"registry.access.redhat.com/ubi8-minimal\"\n\nThe 'oc new-build' command will match arguments to the following types:\n\n  1. Images tagged into image streams in the current project or the 'openshift' project\n     - if you don't specify a tag, we'll add ':latest'\n  2. Images in the Docker Hub, on remote registries, or on the local Docker engine\n  3. Git repository URLs or local paths that point to Git repositories\n\n--allow-missing-images can be used to force the use of an image that was not matched\n\nSee 'oc new-build -h' for examples.", "stderr_lines": ["error: can't lookup images: Timeout: request did not complete within requested timeout context deadline exceeded", "error: unable to locate any images in image streams, local docker images with name \"registry.access.redhat.com/ubi8-minimal\"", "", "The 'oc new-build' command will match arguments to the following types:", "", "  1. Images tagged into image streams in the current project or the 'openshift' project", "     - if you don't specify a tag, we'll add ':latest'", "  2. Images in the Docker Hub, on remote registries, or on the local Docker engine", "  3. Git repository URLs or local paths that point to Git repositories", "", "--allow-missing-images can be used to force the use of an image that was not matched", "", "See 'oc new-build -h' for examples."], "stdout": "", "stdout_lines": []}
```

Not sure what changed (in OCP 4.8?) but adding the explicit `latest` seems to cause this to pass the build stage.