### PR TITLE
Ci opstools fix (#85)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 name: Integration testing
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
+  OPSTOOLS_REPO: https://git.centos.org/rpms/centos-release-opstools/raw/c8s-sig-opstools/f/SOURCES/CentOS-OpsTools.repo
 
   QDR_IMAGE: quay.io/interconnectedcloud/qdrouterd:1.15.0
   QDR_VOLUME: "--volume=${{ github.workspace }}/ci/service_configs/qdr:/etc/qpid-dispatch:ro"
@@ -56,7 +57,7 @@ jobs:
       - name: Start sg-bridge with same branch
         if: steps.bridge_branch.outcome == 'success'
         run: |
-          docker run --name=sgbridge $BRIDGE_VOLUME -d -uroot --network host \
+          docker run --name=sgbridge $BRIDGE_VOLUME -d -uroot --network host -e OPSTOOLS_REPO \
             -e GITHUB_REF -e BRIDGE_SOCKET --workdir=$(dirname $BRIDGE_SOCKET) \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/integration/logging/run_bridge.sh
       - name: Wait for services to start successfuly and print logs
@@ -92,7 +93,7 @@ jobs:
       # run integration tests
       - name: Run sg-core to process log messages
         run: |
-          docker run --name=sgcore -d -uroot --network host $BRIDGE_VOLUME \
+          docker run --name=sgcore -d -uroot --network host $BRIDGE_VOLUME -e OPSTOOLS_REPO \
             --volume ${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/integration/logging/run_sg.sh
       - name: debug

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: CI
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
+  OPSTOOLS_REPO: https://git.centos.org/rpms/centos-release-opstools/raw/c8s-sig-opstools/f/SOURCES/CentOS-OpsTools.repo
 
   LOKI_IMAGE: grafana/loki:2.1.0
   LOKI_VOLUME: "--volume=${{ github.workspace }}/ci/service_configs/loki:/etc/loki:ro"
@@ -64,7 +65,7 @@ jobs:
           docker logs loki
       - name: Run sg-core unit test suite
         run: |
-          docker run --name=testsuite -uroot --network host -e COVERALLS_REPO_TOKEN \
+          docker run --name=testsuite -uroot --network host -e COVERALLS_REPO_TOKEN -e OPSTOOLS_REPO \
             --volume ${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/unit/run_tests.sh
       - name: Send coverage

--- a/build/repos/opstools.repo
+++ b/build/repos/opstools.repo
@@ -1,6 +1,19 @@
+# CentOS-OpsTools.repo
+#
+# Please see http://wiki.centos.org/SpecialInterestGroup/OpsTools for more
+# information
+
+[centos-opstools-testing]
+name=CentOS-OpsTools - testing repo
+baseurl=https://buildlogs.centos.org/centos/$releasever-stream/opstools/$basearch/collectd-5/
+gpgcheck=0
+enabled=0
+
 [centos-opstools]
-name=opstools
-baseurl=http://mirror.centos.org/centos/8/opstools/$basearch/collectd-5/
+name=CentOS-OpsTools - collectd
+mirrorlist=http://mirrorlist.centos.org/?arch=$basearch&release=$releasever-stream&repo=opstools-collectd-5
+#baseurl=http://mirror.centos.org/$contentdir/$releasever-stream/opstools/$basearch/collectd-5/
 gpgcheck=0
 enabled=1
-module_hotfixes=1
+skip_if_unavailable=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-OpsTools

--- a/ci/integration/logging/run_bridge.sh
+++ b/ci/integration/logging/run_bridge.sh
@@ -5,14 +5,8 @@
 set -ex
 
 # enable required repo(s)
-cat > /etc/yum.repos.d/fedora-eln.repo <<EOF
-[centos-opstools]
-name=opstools
-baseurl=http://mirror.centos.org/centos/8/opstools/\$basearch/collectd-5/
-gpgcheck=0
-enabled=1
-module_hotfixes=1
-EOF
+curl -o /etc/yum.repos.d/CentOS-OpsTools.repo $OPSTOOLS_REPO
+sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-OpsTools.repo
 
 dnf install -y git gcc make qpid-proton-c-devel
 

--- a/ci/integration/logging/run_sg.sh
+++ b/ci/integration/logging/run_sg.sh
@@ -5,14 +5,8 @@
 set -ex
 
 # enable required repo(s)
-cat > /etc/yum.repos.d/fedora-eln.repo <<EOF
-[centos-opstools]
-name=opstools
-baseurl=http://mirror.centos.org/centos/8/opstools/\$basearch/collectd-5/
-gpgcheck=0
-enabled=1
-module_hotfixes=1
-EOF
+curl -o /etc/yum.repos.d/CentOS-OpsTools.repo $OPSTOOLS_REPO
+sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-OpsTools.repo
 
 dnf install -y git golang gcc make qpid-proton-c-devel
 

--- a/ci/unit/run_tests.sh
+++ b/ci/unit/run_tests.sh
@@ -5,14 +5,8 @@
 set -ex
 
 # enable required repo(s)
-cat > /etc/yum.repos.d/fedora-eln.repo <<EOF
-[centos-opstools]
-name=opstools
-baseurl=http://mirror.centos.org/centos/8/opstools/\$basearch/collectd-5/
-gpgcheck=0
-enabled=1
-module_hotfixes=1
-EOF
+curl -o /etc/yum.repos.d/CentOS-OpsTools.repo $OPSTOOLS_REPO
+sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-OpsTools.repo
 
 # without glibc-langpack-en locale setting in CentOS8 is broken without this package
 yum install -y git golang gcc make glibc-langpack-en qpid-proton-c-devel


### PR DESCRIPTION
* Fix centos-opstools repo in CI

* Avoid gpgcheck for centos repo

* ... also in repo file

* Update .github/workflows/integration.yml

Co-authored-by: Matthias Runge <mrunge@redhat.com>

* Update .github/workflows/tests.yml

Co-authored-by: Matthias Runge <mrunge@redhat.com>

Co-authored-by: Leif Madsen <lmadsen@redhat.com>
Co-authored-by: Matthias Runge <mrunge@redhat.com>
(cherry picked from commit 04fc6914eaff79d50853249d7ad9dcdaabd05d9a)
(cherry picked from commit 63f8c2c596e69f46ae3657117e1bd40b24e2f30f)