### PR TITLE
Build test plugins for upstream distribution

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . $D/
 COPY build/repos/opstools.repo /etc/yum.repos.d/opstools.repo
 
 RUN dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
-RUN go install golang.org/dl/go1.15@latest && /go/bin/go1.15 download && PRODUCTION_BUILD=true GOCMD=/go/bin/go1.15 ./build.sh
+RUN go install golang.org/dl/go1.15@latest && /go/bin/go1.15 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.15 ./build.sh
 
 # --- end build, create smart gateway layer ---
 FROM registry.access.redhat.com/ubi8-minimal:latest


### PR DESCRIPTION
Build the test plugins dummy-* for upstream builds so that when testing
with smart-gateway-operator by default the plugins exist to simulate
workloads without needing a source connected.

Changes will be used as part of the smart-gateway-operator example
CustomResource and allow for additional molecule testing in the future
for that Operator.
