### PR TITLE
Move to golang 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.15'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       #- name: download libraries
       #  run: go mod download
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.19'
       - name: Verify image builds
         run: |
           docker build --tag infrawatch/sg-core:latest --file build/Dockerfile .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           # Caching conflicts happen in GHA, so just disable for now
           skip-cache: true
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.33
+          version: v1.50
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-20.04

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,19 +26,18 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
     - errcheck
     # - exhaustive
+    - exportloopref
     # - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
@@ -48,10 +47,8 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - rowserrcheck
-    - scopelint
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     # - unused
@@ -59,5 +56,4 @@ linters:
     # NOTE: not all application plugins use ability to emit internal events through
     #       passed bus function in it's constructor.
     #- unparam
-    - varcheck
     # - whitespace

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . $D/
 COPY build/repos/opstools.repo /etc/yum.repos.d/opstools.repo
 
 RUN dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
-RUN go install golang.org/dl/go1.15@latest && /go/bin/go1.15 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.15 ./build.sh
+RUN go install golang.org/dl/go1.19@latest && /go/bin/go1.19 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.19 ./build.sh
 
 # --- end build, create smart gateway layer ---
 FROM registry.access.redhat.com/ubi8-minimal:latest

--- a/ci/integration/logging/run_sg.sh
+++ b/ci/integration/logging/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.15@latest
-go1.15 download
+go install golang.org/dl/go1.19@latest
+go1.19 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.15 ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 ./build.sh
 
 ./sg-core -config ./ci/integration/logging/sg_config.yaml

--- a/ci/integration/metrics/run_sg.sh
+++ b/ci/integration/metrics/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.15@latest
-go1.15 download
+go install golang.org/dl/go1.19@latest
+go1.19 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.15 ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 ./build.sh
 
 ./sg-core -config ./ci/integration/metrics/sg_config.yaml

--- a/ci/unit/run_tests.sh
+++ b/ci/unit/run_tests.sh
@@ -14,8 +14,8 @@ yum install -y git golang gcc make glibc-langpack-en qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.15@latest
-go1.15 download
+go install golang.org/dl/go1.19@latest
+go1.19 download
 
 
-go1.15 test -v -coverprofile=profile.cov ./...
+go1.19 test -v -coverprofile=profile.cov ./...

--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,45 @@
 module github.com/infrawatch/sg-core
 
-go 1.15
+go 1.19
 
 require (
 	collectd.org v0.5.0
 	github.com/Azure/go-amqp v0.13.9
 	github.com/elastic/go-elasticsearch/v7 v7.10.0
 	github.com/go-openapi/errors v0.20.0
-	github.com/go-playground/universal-translator v0.17.0 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/infrawatch/apputils v0.0.0-20210809211320-3573b2937d14
 	github.com/json-iterator/go v1.1.11
-	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/prometheus/common v0.29.0 // indirect
-	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5
 	gopkg.in/errgo.v2 v2.1.0
 	gopkg.in/go-playground/assert.v1 v1.2.1
 	gopkg.in/go-playground/validator.v9 v9.31.0
-	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-ini/ini v1.62.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.29.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/smartystreets/goconvey v1.7.2 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.63.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-openapi/errors v0.20.0
 	github.com/google/uuid v1.2.0
 	github.com/infrawatch/apputils v0.0.0-20210809211320-3573b2937d14
-	github.com/json-iterator/go v1.1.11
+	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.6.1
@@ -32,7 +32,7 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,9 @@ github.com/infrawatch/apputils v0.0.0-20210809211320-3573b2937d14/go.mod h1:be5Y
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -198,8 +199,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,6 @@ github.com/Azure/go-autorest/autorest/adal v0.9.13 h1:Mp5hbtOePIzM8pJVRa3YLrWWmZ
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
-github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
@@ -68,8 +67,9 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -19,7 +18,7 @@ var (
 
 // ParseConfig parses and validates input into config object
 func ParseConfig(r io.Reader, config interface{}) error {
-	configBytes, err := ioutil.ReadAll(r)
+	configBytes, err := io.ReadAll(r)
 	if err != nil {
 		return errors.Wrap(err, "while reading configuration")
 	}

--- a/plugins/application/alertmanager/main.go
+++ b/plugins/application/alertmanager/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 
@@ -94,7 +94,7 @@ func (am *AlertManager) Run(ctx context.Context, done chan bool) {
 						am.logger.Error("failed to report alert to AlertManager")
 					} else if resp.StatusCode != http.StatusOK {
 						// https://github.com/prometheus/alertmanager/blob/master/api/v2/openapi.yaml#L170
-						body, _ := ioutil.ReadAll(resp.Body)
+						body, _ := io.ReadAll(resp.Body)
 						resp.Body.Close()
 						am.logger.Metadata(logging.Metadata{
 							"plugin": appname,

--- a/plugins/application/alertmanager/main_test.go
+++ b/plugins/application/alertmanager/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -166,7 +165,7 @@ var (
 )
 
 func TestAlertmanagerApp(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "alertman_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "alertman_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/plugins/application/elasticsearch/main_test.go
+++ b/plugins/application/elasticsearch/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	stdjson "encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -212,7 +211,7 @@ var (
 )
 
 func TestElasticsearchApp(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "elastic_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "elastic_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/plugins/application/elasticsearch/pkg/lib/client.go
+++ b/plugins/application/elasticsearch/pkg/lib/client.go
@@ -6,8 +6,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	esv7 "github.com/elastic/go-elasticsearch/v7"
@@ -35,7 +35,7 @@ func createTLSConfig(serverName string, certFile string, keyFile string, caFile 
 		return nil, err
 	}
 
-	ca, err := ioutil.ReadFile(caFile)
+	ca, err := os.ReadFile(caFile)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (esc *Client) Connect(cfg *AppConfig) error {
 		return fmt.Errorf("failed to get info from connection: %s", err.Error())
 	}
 	defer res.Body.Close()
-	_, err = io.Copy(ioutil.Discard, res.Body)
+	_, err = io.Copy(io.Discard, res.Body)
 	if err != nil {
 		return fmt.Errorf("failed to discard response body: %s", err.Error())
 	}
@@ -102,7 +102,7 @@ func (esc *Client) IndicesExists(indices []string) (bool, error) {
 		return false, err
 	}
 	defer res.Body.Close()
-	_, err = io.Copy(ioutil.Discard, res.Body)
+	_, err = io.Copy(io.Discard, res.Body)
 	if err != nil {
 		return false, fmt.Errorf("failed to discard response body: %s", err.Error())
 	}
@@ -123,10 +123,10 @@ func (esc *Client) IndicesDelete(indices []string) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotFound {
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("failed to delete indices [%d]: %s", res.StatusCode, body)
 	}
-	_, err = io.Copy(ioutil.Discard, res.Body)
+	_, err = io.Copy(io.Discard, res.Body)
 	if err != nil {
 		return fmt.Errorf("failed to discard response body: %s", err.Error())
 	}
@@ -143,14 +143,14 @@ func (esc *Client) IndicesCreate(indices []string) error {
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 			msg := string(body)
 			if strings.Contains(msg, "resource_already_exists_exception") {
 				return nil
 			}
 			return fmt.Errorf("failed to create index [%d]: %s", res.StatusCode, msg)
 		}
-		_, err = io.Copy(ioutil.Discard, res.Body)
+		_, err = io.Copy(io.Discard, res.Body)
 		if err != nil {
 			return fmt.Errorf("failed to discard response body: %s", err.Error())
 		}
@@ -168,10 +168,10 @@ func (esc *Client) Index(index string, documents []string, bulk bool) error {
 			}
 			defer res.Body.Close()
 			if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-				body, _ := ioutil.ReadAll(res.Body)
+				body, _ := io.ReadAll(res.Body)
 				return fmt.Errorf("failed to index document[%d]: %s", res.StatusCode, body)
 			}
-			_, err = io.Copy(ioutil.Discard, res.Body)
+			_, err = io.Copy(io.Discard, res.Body)
 			if err != nil {
 				return fmt.Errorf("failed to discard response body: %s", err.Error())
 			}
@@ -183,10 +183,10 @@ func (esc *Client) Index(index string, documents []string, bulk bool) error {
 		}
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-			body, _ := ioutil.ReadAll(res.Body)
+			body, _ := io.ReadAll(res.Body)
 			return fmt.Errorf("failed to index document(s)[%d]: %s", res.StatusCode, body)
 		}
-		_, err = io.Copy(ioutil.Discard, res.Body)
+		_, err = io.Copy(io.Discard, res.Body)
 		if err != nil {
 			return fmt.Errorf("failed to discard response body: %s", err.Error())
 		}

--- a/plugins/application/elasticsearch/pkg/lib/client_test.go
+++ b/plugins/application/elasticsearch/pkg/lib/client_test.go
@@ -3,7 +3,7 @@ package lib
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -113,15 +113,15 @@ zKWpPamfIFoJAwMCDScnagYi2J5V51hZOQSld+7T2gyd7B+JcCOBpHvQeRrEknEV
 )
 
 func TestElasticsearchTLSConf(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "connector_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "connector_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 	certpath := path.Join(tmpdir, "cert.pem")
-	require.NoError(t, ioutil.WriteFile(certpath, []byte(testCert), 0600))
+	require.NoError(t, os.WriteFile(certpath, []byte(testCert), 0600))
 	keypath := path.Join(tmpdir, "key.pem")
-	require.NoError(t, ioutil.WriteFile(keypath, []byte(testKey), 0600))
+	require.NoError(t, os.WriteFile(keypath, []byte(testKey), 0600))
 	cacrtpath := path.Join(tmpdir, "ca.pem")
-	require.NoError(t, ioutil.WriteFile(cacrtpath, []byte(testCa), 0600))
+	require.NoError(t, os.WriteFile(cacrtpath, []byte(testCa), 0600))
 
 	t.Run("Test insecure connection.", func(t *testing.T) {
 		tlsConf, err := createTLSConfig("overmind.localdomain", certpath, keypath, cacrtpath)
@@ -146,7 +146,7 @@ func curl(t *testing.T, url string, query string) []byte {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return body
 }

--- a/plugins/application/loki/main_test.go
+++ b/plugins/application/loki/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -135,7 +134,7 @@ var (
 )
 
 func TestLokiApp(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "loki_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "loki_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 

--- a/plugins/application/prometheus/main.go
+++ b/plugins/application/prometheus/main.go
@@ -320,7 +320,7 @@ func (p *Prometheus) Run(ctx context.Context, done chan bool) {
 	// run exporter for prometheus to scrape
 	metricsURL := fmt.Sprintf("%s:%d", p.configuration.Host, p.configuration.Port)
 
-	srv := &http.Server{Addr: metricsURL}
+	srv := &http.Server{Addr: metricsURL, ReadHeaderTimeout: 5 * time.Second}
 	srv.Handler = handler
 
 	wg := new(sync.WaitGroup)

--- a/plugins/handler/ceilometer-metrics/main_test.go
+++ b/plugins/handler/ceilometer-metrics/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -65,7 +65,7 @@ func TestCeilometerIncomingJSON(t *testing.T) {
 		t.Errorf("failed configuring ceilometer handler plugin: %s", err.Error())
 	}
 
-	testData, err := ioutil.ReadFile("messages/metric-tests.json")
+	testData, err := os.ReadFile("messages/metric-tests.json")
 	if err != nil {
 		t.Errorf("failed loading test data: %s", err.Error())
 	}
@@ -102,7 +102,7 @@ func TestCeilometerIncomingMsgpack(t *testing.T) {
 		t.Errorf("failed configuring ceilometer handler plugin: %s", err.Error())
 	}
 
-	testData, err := ioutil.ReadFile("messages/msgpack-test.msgpack")
+	testData, err := os.ReadFile("messages/msgpack-test.msgpack")
 	if err != nil {
 		t.Errorf("failed loading test data: %s", err.Error())
 	}

--- a/plugins/handler/collectd-metrics/main_test.go
+++ b/plugins/handler/collectd-metrics/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testMsgsInvalid map[string]string = map[string]string{
+var testMsgsInvalid = map[string]string{
 	"Null":                    ``,
 	"Non-list":                `{}`,
 	"Empty":                   `[{}]`,
@@ -22,7 +22,7 @@ var testMsgsInvalid map[string]string = map[string]string{
 	"Inconsistent Dimensions": `[{"values": [2121], "dstypes": ["derive","counter"], "dsnames":["samples"], "host":"localhost","plugin":"metric","type":"type0"}]`,
 }
 
-var testMsgsValid map[string]string = map[string]string{
+var testMsgsValid = map[string]string{
 	"Without Instance Types":    `[{"values": [2121], "dstypes": ["derive"], "dsnames":["samples"], "host":"localhost", "plugin":"metric", "type":"type0"}]`,
 	"With Instance Types":       `[{"values": [2122], "dstypes": ["derive"], "dsnames":["samples"], "host":"localhost", "plugin_instance":"plugin0", "type_instance":"type0", "plugin":"metric", "type":"type666"}]`,
 	"Multi-dimensional Metrics": `[{"values": [2112, 1001], "dstypes": ["derive","counter"], "dsnames":["pamples","wamples"], "host":"localhost", "plugin":"metric", "type":"type0"}]`,

--- a/plugins/transport/dummy-alertmanager/main.go
+++ b/plugins/transport/dummy-alertmanager/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -42,7 +42,7 @@ func (dam *DummyAM) Run(ctx context.Context, w transport.WriteFn, done chan bool
 		} else {
 			defer out.Close()
 		}
-		msg, err := ioutil.ReadAll(req.Body)
+		msg, err := io.ReadAll(req.Body)
 		if err != nil {
 			dam.logger.Metadata(logging.Metadata{"plugin": "dummy-alertmanager", "error": err})
 			dam.logger.Error("failed to read request")

--- a/plugins/transport/dummy-alertmanager/main.go
+++ b/plugins/transport/dummy-alertmanager/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/infrawatch/apputils/logging"
 	"github.com/infrawatch/sg-core/pkg/config"

--- a/plugins/transport/dummy-alertmanager/main.go
+++ b/plugins/transport/dummy-alertmanager/main.go
@@ -52,7 +52,7 @@ func (dam *DummyAM) Run(ctx context.Context, w transport.WriteFn, done chan bool
 
 	})
 
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", dam.conf.Port)}
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", dam.conf.Port), ReadHeaderTimeout: 5 * time.Second}
 	go func(server *http.Server, ctx context.Context) {
 		<-ctx.Done()
 		if err := srv.Shutdown(ctx); err != nil {

--- a/plugins/transport/dummy-logs/main.go
+++ b/plugins/transport/dummy-logs/main.go
@@ -9,11 +9,7 @@ import (
 	"github.com/infrawatch/sg-core/pkg/transport"
 )
 
-const maxBufferSize = 4096
-
 var msgBuffer []byte
-
-var sent bool
 
 var logMessages = []string{
 	`", "host":"localhost", "severity":"7", "facility":"daemon", "tag":"rtkit-daemon[734691]:", "source":"rtkit-daemon", "message":"Supervising 0 threads of 0 processes of 0 users.", "file":"", "cloud": "cloud1", "region": "<region-name>"}`,

--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -139,7 +139,7 @@ func (s *Socket) initTCPSocket() *net.TCPListener {
 }
 
 func (s *Socket) WriteTCPMsg(w transport.WriteFn, msgBuffer []byte, n int) (int64, error) {
-	var pos int64 = 0
+	var pos int64
 	var length int64
 	reader := bytes.NewReader(msgBuffer[:n])
 	for pos+msgLengthSize < int64(n) {

--- a/plugins/transport/socket/main.go
+++ b/plugins/transport/socket/main.go
@@ -222,7 +222,7 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 	switch s.conf.Type {
 	case udp:
 		pc = s.initUDPSocket()
-		if pc == nil {
+		if pc == (*net.UDPConn)(nil) {
 			s.logger.Errorf(nil, "Failed to initialize socket transport plugin with type: "+s.conf.Type)
 			return
 		}
@@ -253,7 +253,7 @@ func (s *Socket) Run(ctx context.Context, w transport.WriteFn, done chan bool) {
 		fallthrough
 	default:
 		pc = s.initUnixSocket()
-		if pc == nil {
+		if pc == (*net.UnixConn)(nil) {
 			s.logger.Errorf(nil, "Failed to initialize socket transport plugin with type: "+s.conf.Type)
 			return
 		}

--- a/plugins/transport/socket/main_test.go
+++ b/plugins/transport/socket/main_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -21,7 +20,7 @@ const regularBuffSize = 16384
 const addition = "wubba lubba dub dub"
 
 func TestUnixSocketTransport(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "socket_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -85,7 +84,7 @@ func TestUnixSocketTransport(t *testing.T) {
 }
 
 func TestUdpSocketTransport(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "socket_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -137,7 +136,7 @@ func TestUdpSocketTransport(t *testing.T) {
 }
 
 func TestTcpSocketTransport(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(".", "socket_test_tmp")
+	tmpdir, err := os.MkdirTemp(".", "socket_test_tmp")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 


### PR DESCRIPTION
This patch moves sg-core to golang 1.19. Initially I just updated the `go 1.15` line in go.mod and did `go mod tidy`. 

The build failed like this:

```
$ go version
go version go1.19.4 linux/amd64

$ ./build.sh                       
building amqp1.so                                               
[...]                               
building prometheus.so                     
# github.com/cespare/xxhash/v2                          
asm: xxhash_amd64.s:120: when dynamic linking, R15 is clobbered by a global variable access and is used here: 00092 (/home/csibbitt/go/pkg/mod/github.com/cespare/xxhash/v2@v2.1.1/xxhash_amd6
4.s:120)   ADDQ    R15, AX         
asm: assembly failed
```

I updated that single module and the build worked:

```
$ go get github.com/cespare/xxhash/v2
go: downloading github.com/cespare/xxhash/v2 v2.2.0         
go: upgraded github.com/cespare/xxhash/v2 v2.1.1 => v2.2.0

$ go mod tidy

$ ./build.sh
building amqp1.so
[...]
building prometheus.so

$ echo $?
0

$ ./sg-core -h
Usage: ./sg-core [OPTIONS]

Available options:
  -config string
        configuration file path (default "/etc/sg-core.conf.yaml")
  -cpuprofile string
        write cpu profile to file
[...]
```

`go test ./...` failed for me unfortunately, but it looks like it's because it requires an elaborate test harness. It might be nice some time to break this into two parts so that at least we can run unit tests on the code without needing integration containers. It looks like GHA is going to test this far more thoroughly than I would have ;)

No other testing so far.