### PR TITLE
Specify handler name in handler config error msg

### DIFF
--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -163,7 +163,7 @@ func SetTransportHandlers(name string, handlerBlocks []struct {
 
 		err = h.Config(configBlob)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed configuring handler plugin '%s'", block.Name)
 		}
 
 		handlers[name] = append(handlers[name], h)


### PR DESCRIPTION
Before: 
```
[ERROR] transport handlers failed to load [transport: dummy-logs0, error: missing or incorrect configuration fields --  messageField , timestampField , hostnameField , severityField --]
```

Now:
```
[ERROR] transport handlers failed to load [transport: dummy-logs0, error: failed configuring handler plugin 'logs': missing or incorrect configuration fields --  messageField , timestampField , hostnameField , severityField --]
```

Solves issue #49 