### PR TITLE
Fix integration CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -171,7 +171,7 @@ jobs:
             $RSYSLOG_IMAGE bash $PROJECT_ROOT/ci/integration/logging/run_rsyslog.sh
       - name: Wait for services to start successfuly
         run: |
-          timeout=180
+          timeout=240
           echo "======================= rsyslog ======================="
           rsyslog_wait=0
           while [[ $(docker exec qdr qdstat -b 127.0.0.1:5666 -a | grep rsyslog/logs | awk '{print $8}') -le 0 ]]

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ base=$(pwd)
 GOCMD=${GOCMD:-"go"}
 PLUGIN_DIR=${PLUGIN_DIR:-"/tmp/plugins/"}
 CONTAINER_BUILD=${CONTAINER_BUILD:-false}
-BUILD_ARGS=${BUILD_ARGS:-'-buildvcs=false'}
+BUILD_ARGS=${BUILD_ARGS:-''}
 
 PRODUCTION_BUILD=${PRODUCTION_BUILD:-false}
 if $PRODUCTION_BUILD; then

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ base=$(pwd)
 GOCMD=${GOCMD:-"go"}
 PLUGIN_DIR=${PLUGIN_DIR:-"/tmp/plugins/"}
 CONTAINER_BUILD=${CONTAINER_BUILD:-false}
+BUILD_ARGS=${BUILD_ARGS:-'-buildvcs=false'}
 
 PRODUCTION_BUILD=${PRODUCTION_BUILD:-false}
 if $PRODUCTION_BUILD; then
@@ -60,7 +61,7 @@ build_plugins() {
     search_list "$(basename $i)" OMIT_TRANSPORTS
     if [ $? -ne 1 ]; then
       echo "building $(basename $i).so"
-      $GOCMD build -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
+      $GOCMD build $BUILD_ARGS -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
     fi
   done
 
@@ -71,7 +72,7 @@ build_plugins() {
     search_list "$(basename $i)" OMIT_HANDLERS
     if [ $? -ne 1 ]; then
       echo "building $(basename $i).so"
-      $GOCMD build -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
+      $GOCMD build $BUILD_ARGS -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
     fi
   done
 
@@ -82,7 +83,7 @@ build_plugins() {
     search_list "$(basename $i)" OMIT_APPLICATIONS
     if [ $? -ne 1 ]; then
       echo "building $(basename $i).so"
-      $GOCMD build -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
+      $GOCMD build $BUILD_ARGS -o "$PLUGIN_DIR$(basename $i).so" -buildmode=plugin
     fi
   done
 }
@@ -92,9 +93,9 @@ build_core() {
   cd "$base"
   if $CONTAINER_BUILD; then
       echo "building sg-core for container"
-      $GOCMD build -o /tmp/sg-core cmd/*.go
+      $GOCMD build $BUILD_ARGS -o /tmp/sg-core cmd/*.go
   else
-      $GOCMD build -o sg-core cmd/*.go
+      $GOCMD build $BUILD_ARGS -o sg-core cmd/*.go
   fi
 }
 

--- a/ci/integration/logging/run_sg.sh
+++ b/ci/integration/logging/run_sg.sh
@@ -18,6 +18,6 @@ go1.19 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
 
 ./sg-core -config ./ci/integration/logging/sg_config.yaml

--- a/ci/integration/metrics/run_sg.sh
+++ b/ci/integration/metrics/run_sg.sh
@@ -18,6 +18,8 @@ go1.19 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
+
+ls /usr/lib64/sg-core/
 
 ./sg-core -config ./ci/integration/metrics/sg_config.yaml

--- a/ci/integration/metrics/run_sg.sh
+++ b/ci/integration/metrics/run_sg.sh
@@ -20,6 +20,4 @@ go1.19 download
 mkdir -p /usr/lib64/sg-core
 PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
 
-ls /usr/lib64/sg-core/
-
 ./sg-core -config ./ci/integration/metrics/sg_config.yaml


### PR DESCRIPTION
This should fix the integration CI.

It looks like the sg-core's plugins aren't inside the plugin folder. I see the following errors in the CI output when it's trying to build the plugins:
```
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```

From what I found, go >= 1.18 is adding some version control information to the built binaries and this seems to be failing right now. This PR disables that. I don't see the feature being much useful. If we decide it is useful, we can find another way.