### PR TITLE
Add qdr log output to CI (trying to debug a CI issue)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,13 +104,14 @@ jobs:
           sleep 360
           echo "=========================== qdr =========================" && \
           docker exec qdr qdstat -b 127.0.0.1:5666 -a
+          docker logs qdr
           echo "========================= sg-core =======================" && \
           docker logs sgcore
           echo "======================== collectd =======================" && \
           cat /var/log/collectd.log
           echo "========================= ceilometer ====================" && \
           sudo journalctl -xu devstack@ceilometer-anotification.service
-          echo "========================= sg-core =======================" && \
+          echo "======================== prometheus =====================" && \
           docker logs prometheus
       - name: Validate metrics processing
         run: |


### PR DESCRIPTION
Sometimes the CI fails with ceilometer timing out
when trying to send metrics. I hope that these logs make it clearer what is happening.