### PR TITLE
Remove sg-core & prometheus containers with force

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -90,7 +90,7 @@ if is_service_enabled sg-core; then
 
 		if [[ "$1" == "unstack" ]]; then
 			$SG_CORE_CONTAINER_EXECUTABLE stop sg-core
-			$SG_CORE_CONTAINER_EXECUTABLE rm sg-core
+			$SG_CORE_CONTAINER_EXECUTABLE rm -f sg-core
 		fi
 
 		if [[ "$1" == "clean" ]]; then
@@ -121,7 +121,7 @@ if is_service_enabled sg-core; then
 
 		if [[ "$1" == "unstack" ]]; then
 			$PROMETHEUS_CONTAINER_EXECUTABLE stop prometheus
-			$PROMETHEUS_CONTAINER_EXECUTABLE rm prometheus
+			$PROMETHEUS_CONTAINER_EXECUTABLE rm -f prometheus
 		fi
 
 		if [[ "$1" == "clean" ]]; then


### PR DESCRIPTION
Often times during unstack, containers get stuck in "Stopping" state and do not get cleaned up. These left over containers cause next run of stack.sh to fail because the script tries to spawn them with the name same.