### PR TITLE
Move to golang 1.20 (#127)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - uses: actions/checkout@v3
       #- name: download libraries
       #  run: go mod download
@@ -33,7 +33,7 @@ jobs:
           # Caching conflicts happen in GHA, so just disable for now
           skip-cache: true
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.50
+          version: v1.51
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-20.04
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Verify image builds
         run: |
           docker build --tag infrawatch/sg-core:latest --file build/Dockerfile .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . $D/
 COPY build/repos/opstools.repo /etc/yum.repos.d/opstools.repo
 
 RUN dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
-RUN go install golang.org/dl/go1.19@latest && /go/bin/go1.19 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.19 ./build.sh
+RUN go install golang.org/dl/go1.20@latest && /go/bin/go1.20 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.20 ./build.sh
 
 # --- end build, create smart gateway layer ---
 FROM registry.access.redhat.com/ubi8-minimal:latest

--- a/ci/integration/logging/run_sg.sh
+++ b/ci/integration/logging/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.19@latest
-go1.19 download
+go install golang.org/dl/go1.20@latest
+go1.20 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.20 BUILD_ARGS=-buildvcs=false ./build.sh
 
 ./sg-core -config ./ci/integration/logging/sg_config.yaml

--- a/ci/integration/metrics/ceilometer/bridge/run_sg.sh
+++ b/ci/integration/metrics/ceilometer/bridge/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.19@latest
-go1.19 download
+go install golang.org/dl/go1.20@latest
+go1.20 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.20 BUILD_ARGS=-buildvcs=false ./build.sh
 
 ./sg-core -config ./ci/integration/metrics/ceilometer/bridge/sg_config.yaml

--- a/ci/integration/metrics/ceilometer/tcp/run_sg.sh
+++ b/ci/integration/metrics/ceilometer/tcp/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.19@latest
-go1.19 download
+go install golang.org/dl/go1.20@latest
+go1.20 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.20 BUILD_ARGS=-buildvcs=false ./build.sh
 
 ./sg-core -config ./ci/integration/metrics/ceilometer/tcp/sg_config.yaml

--- a/ci/integration/metrics/collectd/run_sg.sh
+++ b/ci/integration/metrics/collectd/run_sg.sh
@@ -13,11 +13,11 @@ dnf install -y git golang gcc make qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.19@latest
-go1.19 download
+go install golang.org/dl/go1.20@latest
+go1.20 download
 
 # install sg-core and start sg-core
 mkdir -p /usr/lib64/sg-core
-PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.19 BUILD_ARGS=-buildvcs=false ./build.sh
+PLUGIN_DIR=/usr/lib64/sg-core/ GOCMD=go1.20 BUILD_ARGS=-buildvcs=false ./build.sh
 
 ./sg-core -config ./ci/integration/metrics/collectd/sg_config.yaml

--- a/ci/unit/run_tests.sh
+++ b/ci/unit/run_tests.sh
@@ -14,8 +14,8 @@ yum install -y git golang gcc make glibc-langpack-en qpid-proton-c-devel
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
 
-go install golang.org/dl/go1.19@latest
-go1.19 download
+go install golang.org/dl/go1.20@latest
+go1.20 download
 
 
-go1.19 test -v -coverprofile=profile.cov ./...
+go1.20 test -v -coverprofile=profile.cov ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/infrawatch/sg-core
 
-go 1.19
+go 1.20
 
 require (
 	collectd.org v0.5.0


### PR DESCRIPTION
* Move to golang 1.20

* Bump golangci-lint to 1.51 for golang 1.20 support

(cherry picked from commit 35d6fbeac82fc3313f8d73bca28cf5fc6f18d5cf)