### PR TITLE
Remove neutron customization from local.conf

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,6 +50,7 @@ jobs:
           SOURCE=$(pwd)
           git clone http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
+          git fetch https://review.opendev.org/openstack/devstack refs/changes/40/914440/1 && git checkout FETCH_HEAD
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update
           ./stack.sh
@@ -144,6 +145,7 @@ jobs:
           SOURCE=$(pwd)
           git clone http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
+          git fetch https://review.opendev.org/openstack/devstack refs/changes/40/914440/1 && git checkout FETCH_HEAD
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update
           ./stack.sh
@@ -242,6 +244,7 @@ jobs:
           SOURCE=$(pwd)
           git clone http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
+          git fetch https://review.opendev.org/openstack/devstack refs/changes/40/914440/1 && git checkout FETCH_HEAD
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update
           ./stack.sh


### PR DESCRIPTION
We have an issue in CI, where devstack can't install successfully because of neutron plugin failing to copy some files.

This is an attempt to fix the CI by moving the local.conf a little closer to what worked for me when deploying devstack localy recently.