### PR TITLE
Bump actions checkout to v4

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
       PROMETHEUS_IMAGE: prom/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       - name: Prepare environment
         run: |
           mkdir -p /opt/stack/
@@ -119,7 +119,7 @@ jobs:
       PROMETHEUS_IMAGE: prom/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       - name: Prepare environment
         run: |
           mkdir -p /opt/stack/
@@ -217,7 +217,7 @@ jobs:
       PROMETHEUS_IMAGE: prom/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       - name: Prepare environment
         run: |
           mkdir -p /opt/stack/
@@ -299,7 +299,7 @@ jobs:
       RSYSLOG_VOLUME: "--volume ${{ github.workspace }}/ci/service_configs/rsyslog/rsyslog_config.conf:/etc/rsyslog.d/integration.conf:z"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.3
       # start data store services
       - name: Start Elasticsearch service
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-20.04
     container: 'quay.io/plmr/sg-core-ci'
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.3
       #- name: download libraries
       #  run: go mod download
       - name: golangci-lint
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.3
       # start services
       - name: Start Elasticsearch service
         run: |
@@ -68,15 +68,15 @@ jobs:
             --volume ${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/unit/run_tests.sh
       - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
+        uses: shogo82148/actions-goveralls@v1.8.0
         with:
           path-to-profile: ${{ github.workspace }}/profile.cov
   image-build:
     name: Image build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4.1.3
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
       - name: Verify image builds

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: update PR with coveralls badge
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Bump actions checkout to v4 since Node.js 16 actions are deprecated.
We need to update to Node.js 20, which is included in actions/checkout@v4.

Also bumps setup-go, actions-goveralls and github-script