### PR TITLE
Fix sg-bridge in integration CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           docker run --name=sgbridge --network host $BRIDGE_VOLUME -d -uroot \
             -e GITHUB_REF -e BRIDGE_SOCKET -e QDR_CHANNEL -e OPSTOOLS_REPO \
-            --workdir=$(dirname $BRIDGE_SOCKET) \
+            --workdir=$(dirname $BRIDGE_SOCKET) --volume ${{ github.workspace }}:$PROJECT_ROOT:z \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/integration/metrics/run_bridge.sh
       - name: Install collectd
         run: |
@@ -171,7 +171,7 @@ jobs:
         run: |
           docker run --name=sgbridge --network host $BRIDGE_VOLUME -d -uroot \
             -e GITHUB_REF -e BRIDGE_SOCKET -e QDR_CHANNEL -e OPSTOOLS_REPO \
-            --workdir=$(dirname $BRIDGE_SOCKET) \
+            --workdir=$(dirname $BRIDGE_SOCKET) --volume ${{ github.workspace }}:$PROJECT_ROOT:z \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/integration/metrics/run_bridge.sh
       - name: Set Ceilometer pipelines to QDR output and restart notification agent
         run: |
@@ -334,7 +334,7 @@ jobs:
         if: steps.bridge_branch.outcome == 'success'
         run: |
           docker run --name=sgbridge $BRIDGE_VOLUME -d -uroot --network host -e OPSTOOLS_REPO \
-            -e GITHUB_REF -e BRIDGE_SOCKET --workdir=$(dirname $BRIDGE_SOCKET) \
+            -e GITHUB_REF -e BRIDGE_SOCKET --workdir=$(dirname $BRIDGE_SOCKET) --volume ${{ github.workspace }}:$PROJECT_ROOT:z \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/integration/logging/run_bridge.sh
       - name: Run rsyslog to produce log messages
         run: |

--- a/ci/integration/logging/run_bridge.sh
+++ b/ci/integration/logging/run_bridge.sh
@@ -8,7 +8,7 @@ set -ex
 curl -o /etc/yum.repos.d/CentOS-OpsTools.repo $OPSTOOLS_REPO
 sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-OpsTools.repo
 
-dnf install -y git gcc make qpid-proton-c-devel
+dnf install -y git gcc make qpid-proton-c-devel redhat-rpm-config
 
 # install and start sg-bridge
 BRANCH="$(echo ${GITHUB_REF#refs/heads/})"

--- a/ci/integration/metrics/run_bridge.sh
+++ b/ci/integration/metrics/run_bridge.sh
@@ -10,7 +10,7 @@ CHANNEL=$QDR_CHANNEL
 curl -o /etc/yum.repos.d/CentOS-OpsTools.repo $OPSTOOLS_REPO
 sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/CentOS-OpsTools.repo
 
-dnf install -y git gcc make qpid-proton-c-devel
+dnf install -y git gcc make qpid-proton-c-devel redhat-rpm-config
 
 # install and start sg-bridge
 BRANCH="$(echo ${GITHUB_REF#refs/heads/})"


### PR DESCRIPTION
We were missing a volume in the sg-bridge container and a package, which is required for building sg-bridge from source. I tested with a same named branch in sg-bridge repo, so the CI should be green even on a run after merge.