### PR TITLE
Update coveralls update job

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: update PR with coveralls badge
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var BRANCH_NAME = process.env.BRANCH_NAME;
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Since github-script v5, the correct syntax for adding a comment is github.rest.issues.createComment instead of github.issues.createComment

See https://github.com/marketplace/actions/github-script

Also updates the github-script to latest available version