### PR TITLE
Update GH actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,6 @@ jobs:
         run: |
           sudo apt install postgresql-client-common
           sudo apt install postgresql-common
-          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |
@@ -137,7 +136,6 @@ jobs:
         run: |
           sudo apt install postgresql-client-common
           sudo apt install postgresql-common
-          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |
@@ -236,7 +234,6 @@ jobs:
         run: |
           sudo apt install postgresql-client-common
           sudo apt install postgresql-common
-          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,8 +40,7 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=253
+          sudo apt install postgresql-client-common
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
@@ -136,8 +135,7 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=253
+          sudo apt install postgresql-client-common
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
@@ -236,8 +234,7 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=253
+          sudo apt install postgresql-client-common
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Prepare environment for postgres-server installation
         run: |
           sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=238
+          sudo apt install postgresql-client-common=253
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
@@ -137,7 +137,7 @@ jobs:
       - name: Prepare environment for postgres-server installation
         run: |
           sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=238
+          sudo apt install postgresql-client-common=253
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
@@ -237,7 +237,7 @@ jobs:
       - name: Prepare environment for postgres-server installation
         run: |
           sudo apt remove postgresql-client-common
-          sudo apt install postgresql-client-common=238
+          sudo apt install postgresql-client-common=253
           sudo apt install postgresql-common
           sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   collectd-metrics-bridge:
     name: "[metrics] transport: socket(sg-bridge); handler: collectd-metrics; application: prometheus"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       QDR_CHANNEL: collectd/metrics
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
@@ -40,8 +40,10 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt install postgresql-client-common
+          sudo apt remove postgresql-client-common
+          sudo apt install postgresql-client-common=238
           sudo apt install postgresql-common
+          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |
@@ -112,7 +114,7 @@ jobs:
 #-------------------------------------------------------------------------------
   ceilometer-metrics-bridge:
     name: "[metrics] transport: socket(sg-bridge); handler: ceilometer-metrics; application: prometheus"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       QDR_CHANNEL: anycast/ceilometer/metering.sample
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
@@ -134,8 +136,10 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt install postgresql-client-common
+          sudo apt remove postgresql-client-common
+          sudo apt install postgresql-client-common=238
           sudo apt install postgresql-common
+          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |
@@ -212,7 +216,7 @@ jobs:
 #-------------------------------------------------------------------------------
   ceilometer-metrics-tcp:
     name: "[metrics] transport: socket(tcp); handler: ceilometer-metrics; application: prometheus"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PROMETHEUS_IMAGE: prom/prometheus:latest
     steps:
@@ -232,8 +236,10 @@ jobs:
           sudo apt-get clean
       - name: Prepare environment for postgres-server installation
         run: |
-          sudo apt install postgresql-client-common
+          sudo apt remove postgresql-client-common
+          sudo apt install postgresql-client-common=238
           sudo apt install postgresql-common
+          sudo python -m pip install --upgrade pip
           sudo python -m pip install --upgrade virtualenv
       - name: Install devstack
         run: |
@@ -286,7 +292,7 @@ jobs:
     # determine the functionality is useful.
     if: false
     name: "[logging] handler: logs; application: elasticsearch, loki"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   collectd-metrics-bridge:
     name: "[metrics] transport: socket(sg-bridge); handler: collectd-metrics; application: prometheus"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       QDR_CHANNEL: collectd/metrics
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
@@ -114,7 +114,7 @@ jobs:
 #-------------------------------------------------------------------------------
   ceilometer-metrics-bridge:
     name: "[metrics] transport: socket(sg-bridge); handler: ceilometer-metrics; application: prometheus"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       QDR_CHANNEL: anycast/ceilometer/metering.sample
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
@@ -216,7 +216,7 @@ jobs:
 #-------------------------------------------------------------------------------
   ceilometer-metrics-tcp:
     name: "[metrics] transport: socket(tcp); handler: ceilometer-metrics; application: prometheus"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PROMETHEUS_IMAGE: prom/prometheus:latest
     steps:
@@ -292,7 +292,7 @@ jobs:
     # determine the functionality is useful.
     if: false
     name: "[logging] handler: logs; application: elasticsearch, loki"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       BRIDGE_SOCKET: /tmp/sg-bridge/test-socket
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   golangci:
     name: Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -35,7 +35,7 @@ jobs:
           version: v1.51
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.3
@@ -72,7 +72,7 @@ jobs:
           path-to-profile: ${{ github.workspace }}/profile.cov
   image-build:
     name: Image build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.3
       - uses: actions/setup-go@v5

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -16,7 +16,7 @@ jobs:
 #        (github.event.issue.author_association == 'CONTRIBUTOR') ||
 #        (github.event.issue.author_association == 'MEMBER')
 #      )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: update PR with coveralls badge
         uses: actions/github-script@v7.0.1


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.

Actions need to be updated to a newer version.

For some jobs we are already using ubuntu-latest, so use the same for the jobs using ubuntu20.04