### PR TITLE
Pin Devstack version to stable/2024.2

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install devstack
         run: |
           SOURCE=$(pwd)
-          git clone http://github.com/openstack/devstack /opt/stack/devstack
+          git clone -b stable/2024.2 http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update
@@ -144,7 +144,7 @@ jobs:
       - name: Install devstack
         run: |
           SOURCE=$(pwd)
-          git clone http://github.com/openstack/devstack /opt/stack/devstack
+          git clone -b stable/2024.2 http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update
@@ -244,7 +244,7 @@ jobs:
       - name: Install devstack
         run: |
           SOURCE=$(pwd)
-          git clone http://github.com/openstack/devstack /opt/stack/devstack
+          git clone -b stable/2024.2 http://github.com/openstack/devstack /opt/stack/devstack
           pushd /opt/stack/devstack
           cp $SOURCE/ci/integration/metrics/local.conf .
           sudo apt-get update


### PR DESCRIPTION
The deprecation of AMQP1 driver in Oslo messaging [1] broke our integration jobs

Since infrawatch/sg-core is used in STF and STF is being used with a stable OSP version, we can safely pin to the latest stable version available for Devstack and use it as a base for our integration jobs

This version corresponds with stable/2024.2, Dalmatian [2]

[1] https://github.com/openstack/oslo.messaging/commit/7997a199acada382b0c61dc84aa956e4c65de986
[2] https://docs.openstack.org/2024.2/