### PR TITLE
Use repository opstools repo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration testing
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
-  OPSTOOLS_REPO: https://trunk.rdoproject.org/centos9-caracal/delorean-deps.repo
+  OPSTOOLS_REPO: https://raw.githubusercontent.com/infrawatch/sg-core/0d28a1c2f87bd64f2d67effcda926855af057a82/build/repos/opstools.repo
 
   QDR_IMAGE: quay.io/interconnectedcloud/qdrouterd:1.17.0
   QDR_VOLUME: "--volume=${{ github.workspace }}/ci/service_configs/qdr:/etc/qpid-dispatch:ro"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
-  OPSTOOLS_REPO: https://trunk.rdoproject.org/centos9-caracal/delorean-deps.repo
+  OPSTOOLS_REPO: https://raw.githubusercontent.com/infrawatch/sg-core/0d28a1c2f87bd64f2d67effcda926855af057a82/build/repos/opstools.repo
 
   LOKI_IMAGE: quay.io/infrawatch/loki:2.4.2
   LOKI_VOLUME: "--volume=${{ github.workspace }}/ci/service_configs/loki:/etc/loki:ro"


### PR DESCRIPTION
Avoid enabling unnecessary repos in Caracal by using the repo copy of opstools