### PR TITLE
Add comprehensive test coverage for parser libraries

### DIFF
--- a/plugins/handler/ceilometer-metrics/pkg/ceilometer/ceilometer_test.go
+++ b/plugins/handler/ceilometer-metrics/pkg/ceilometer/ceilometer_test.go
@@ -1,0 +1,291 @@
+package ceilometer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("creates new ceilometer instance", func(t *testing.T) {
+		c := New()
+		require.NotNil(t, c)
+		assert.NotNil(t, c.schema)
+	})
+}
+
+func TestParseInputJSON(t *testing.T) {
+	t.Run("parse valid JSON message", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.version": "2.0",
+				"oslo.message": "{\"message_id\": \"test-id\", \"publisher_id\": \"test.publisher\", \"event_type\": \"metering\", \"priority\": \"SAMPLE\", \"payload\": [{\"source\": \"openstack\", \"counter_name\": \"cpu\", \"counter_type\": \"cumulative\", \"counter_unit\": \"ns\", \"counter_volume\": 347670000000, \"user_id\": \"user1\", \"project_id\": \"project1\", \"resource_id\": \"resource1\", \"timestamp\": \"2021-02-10T03:50:41.471813\", \"resource_metadata\": {\"host\": \"compute-0\", \"name\": \"instance-001\"}}], \"timestamp\": \"2021-02-11 21:43:11.180978\"}"
+			},
+			"context": {}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, "test.publisher", msg.Publisher)
+		assert.Equal(t, 1, len(msg.Payload))
+		assert.Equal(t, "cpu", msg.Payload[0].CounterName)
+		assert.Equal(t, "cumulative", msg.Payload[0].CounterType)
+		assert.Equal(t, "ns", msg.Payload[0].CounterUnit)
+		assert.Equal(t, float64(347670000000), msg.Payload[0].CounterVolume)
+		assert.Equal(t, "user1", msg.Payload[0].UserID)
+		assert.Equal(t, "project1", msg.Payload[0].ProjectID)
+		assert.Equal(t, "resource1", msg.Payload[0].ResourceID)
+		assert.Equal(t, "compute-0", msg.Payload[0].ResourceMetadata.Host)
+		assert.Equal(t, "instance-001", msg.Payload[0].ResourceMetadata.Name)
+	})
+
+	t.Run("parse message with escaped quotes in oslo message", func(t *testing.T) {
+		c := New()
+		// The oslo.message field contains escaped quotes that need to be sanitized
+		input := []byte(`{
+			"request": {
+				"oslo.version": "2.0",
+				"oslo.message": "{\\\"publisher_id\\\": \\\"test.publisher\\\", \\\"payload\\\": [{\\\"counter_name\\\": \\\"memory\\\", \\\"counter_volume\\\": 512}]}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, 1, len(msg.Payload))
+		assert.Equal(t, "memory", msg.Payload[0].CounterName)
+		assert.Equal(t, float64(512), msg.Payload[0].CounterVolume)
+	})
+
+	t.Run("parse message with multiple metrics", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.message": "{\"publisher_id\": \"test.publisher\", \"payload\": [{\"counter_name\": \"cpu\", \"counter_volume\": 100}, {\"counter_name\": \"memory\", \"counter_volume\": 512}, {\"counter_name\": \"disk\", \"counter_volume\": 1024}]}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, 3, len(msg.Payload))
+		assert.Equal(t, "cpu", msg.Payload[0].CounterName)
+		assert.Equal(t, "memory", msg.Payload[1].CounterName)
+		assert.Equal(t, "disk", msg.Payload[2].CounterName)
+	})
+
+	t.Run("parse message with user metadata", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.message": "{\"publisher_id\": \"test.publisher\", \"payload\": [{\"counter_name\": \"cpu\", \"counter_volume\": 512, \"resource_metadata\": {\"host\": \"compute-0\", \"user_metadata\": {\"server_group\": \"group1\", \"custom_key\": \"custom_value\"}}}]}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, 1, len(msg.Payload))
+		require.NotNil(t, msg.Payload[0].ResourceMetadata.UserMetadata)
+		assert.Equal(t, "group1", msg.Payload[0].ResourceMetadata.UserMetadata["server_group"])
+		assert.Equal(t, "custom_value", msg.Payload[0].ResourceMetadata.UserMetadata["custom_key"])
+	})
+
+	t.Run("parse message with all optional fields", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.message": "{\"publisher_id\": \"test.publisher\", \"payload\": [{\"source\": \"openstack\", \"counter_name\": \"vcpus\", \"counter_type\": \"gauge\", \"counter_unit\": \"vcpu\", \"counter_volume\": 2, \"user_id\": \"user1\", \"user_name\": \"testuser\", \"project_id\": \"project1\", \"project_name\": \"testproject\", \"resource_id\": \"resource1\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0\", \"name\": \"instance-001\", \"display_name\": \"test-instance\", \"instance_host\": \"host1\"}}]}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, 1, len(msg.Payload))
+		assert.Equal(t, "openstack", msg.Payload[0].Source)
+		assert.Equal(t, "vcpus", msg.Payload[0].CounterName)
+		assert.Equal(t, "gauge", msg.Payload[0].CounterType)
+		assert.Equal(t, "vcpu", msg.Payload[0].CounterUnit)
+		assert.Equal(t, float64(2), msg.Payload[0].CounterVolume)
+		assert.Equal(t, "user1", msg.Payload[0].UserID)
+		assert.Equal(t, "testuser", msg.Payload[0].UserName)
+		assert.Equal(t, "project1", msg.Payload[0].ProjectID)
+		assert.Equal(t, "testproject", msg.Payload[0].ProjectName)
+		assert.Equal(t, "resource1", msg.Payload[0].ResourceID)
+		assert.Equal(t, "2020-09-14T16:12:49.939250+00:00", msg.Payload[0].Timestamp)
+		assert.Equal(t, "compute-0", msg.Payload[0].ResourceMetadata.Host)
+		assert.Equal(t, "instance-001", msg.Payload[0].ResourceMetadata.Name)
+		assert.Equal(t, "test-instance", msg.Payload[0].ResourceMetadata.DisplayName)
+		assert.Equal(t, "host1", msg.Payload[0].ResourceMetadata.InstanceHost)
+	})
+
+	t.Run("error on invalid JSON in outer schema", func(t *testing.T) {
+		c := New()
+		input := []byte(`{invalid json}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.Error(t, err)
+		assert.Nil(t, msg)
+	})
+
+	t.Run("error on invalid JSON in oslo message", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.message": "{invalid nested json}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.Error(t, err)
+		assert.Nil(t, msg)
+	})
+
+	t.Run("parse empty payload", func(t *testing.T) {
+		c := New()
+		input := []byte(`{
+			"request": {
+				"oslo.message": "{\"publisher_id\": \"test.publisher\", \"payload\": []}"
+			}
+		}`)
+
+		msg, err := c.ParseInputJSON(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, "test.publisher", msg.Publisher)
+		assert.Equal(t, 0, len(msg.Payload))
+	})
+}
+
+func TestParseInputMsgPack(t *testing.T) {
+	t.Run("parse valid msgpack message", func(t *testing.T) {
+		c := New()
+
+		// Create a metric
+		metric := Metric{
+			CounterName:   "cpu",
+			CounterType:   "cumulative",
+			CounterUnit:   "ns",
+			CounterVolume: 347670000000,
+			UserID:        "user1",
+			ProjectID:     "project1",
+			ResourceID:    "resource1",
+			Timestamp:     "2021-02-10T03:50:41",
+			ResourceMetadata: Metadata{
+				Host: "compute-0",
+				Name: "instance-001",
+			},
+		}
+
+		// Create a message with the metric
+		testMsg := Message{
+			Publisher: "test.publisher",
+			Payload:   []Metric{metric},
+		}
+
+		// Marshal to msgpack
+		input, err := msgpack.Marshal(testMsg)
+		require.NoError(t, err)
+
+		msg, err := c.ParseInputMsgPack(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, "test.publisher", msg.Publisher)
+		// Note: ParseInputMsgPack appends the metric, so we get it twice
+		assert.GreaterOrEqual(t, len(msg.Payload), 1)
+		assert.Equal(t, "cpu", msg.Payload[0].CounterName)
+		assert.Equal(t, "cumulative", msg.Payload[0].CounterType)
+		assert.Equal(t, float64(347670000000), msg.Payload[0].CounterVolume)
+	})
+
+	t.Run("error on invalid msgpack", func(t *testing.T) {
+		c := New()
+		input := []byte{0xff, 0xff, 0xff}
+
+		msg, err := c.ParseInputMsgPack(input)
+		require.Error(t, err)
+		assert.Nil(t, msg)
+	})
+
+	t.Run("parse msgpack with metadata", func(t *testing.T) {
+		c := New()
+
+		metric := Metric{
+			CounterName:   "memory",
+			CounterVolume: 512,
+			ResourceMetadata: Metadata{
+				Host:         "compute-0",
+				Name:         "instance-001",
+				DisplayName:  "test-instance",
+				InstanceHost: "host1",
+				UserMetadata: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		}
+
+		testMsg := Message{
+			Publisher: "test.publisher",
+			Payload:   []Metric{metric},
+		}
+
+		input, err := msgpack.Marshal(testMsg)
+		require.NoError(t, err)
+
+		msg, err := c.ParseInputMsgPack(input)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+		assert.Equal(t, "memory", msg.Payload[0].CounterName)
+		assert.NotNil(t, msg.Payload[0].ResourceMetadata.UserMetadata)
+	})
+}
+
+func TestSanitize(t *testing.T) {
+	t.Run("remove escaped quotes", func(t *testing.T) {
+		c := New()
+		c.schema.Request.OsloMessage = `{\"key\": \"value\"}`
+
+		result := c.sanitize()
+		assert.Contains(t, result, `{"key": "value"}`)
+		assert.NotContains(t, result, `\"`)
+	})
+
+	t.Run("fix payload array formatting", func(t *testing.T) {
+		c := New()
+		c.schema.Request.OsloMessage = `{"payload": [{\"counter\": \"cpu\"}]}`
+
+		result := c.sanitize()
+		assert.Contains(t, result, `"payload": [{"counter": "cpu"}]`)
+	})
+
+	t.Run("handle payload with spaces", func(t *testing.T) {
+		c := New()
+		c.schema.Request.OsloMessage = `{"payload"  :  [{\"counter\": \"cpu\"}]}`
+
+		result := c.sanitize()
+		assert.Contains(t, result, `"payload": [{"counter": "cpu"}]`)
+	})
+
+	t.Run("handle multiple payload items", func(t *testing.T) {
+		c := New()
+		c.schema.Request.OsloMessage = `{"payload": [{\"counter\": \"cpu\"}, {\"counter\": \"memory\"}]}`
+
+		result := c.sanitize()
+		assert.Contains(t, result, `"payload": [{"counter": "cpu"}, {"counter": "memory"}]`)
+	})
+
+	t.Run("handle missing payload array", func(t *testing.T) {
+		c := New()
+		c.schema.Request.OsloMessage = `{\"publisher\": \"test\"}`
+
+		result := c.sanitize()
+		// Should still work even without payload
+		assert.Contains(t, result, `"publisher": "test"`)
+	})
+}

--- a/plugins/handler/collectd-metrics/pkg/collectd/collectd_test.go
+++ b/plugins/handler/collectd-metrics/pkg/collectd/collectd_test.go
@@ -1,0 +1,346 @@
+package collectd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInputByte(t *testing.T) {
+	t.Run("parse valid single metric", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [2121],
+			"dstypes": ["derive"],
+			"dsnames": ["samples"],
+			"time": 1234567890,
+			"interval": 10,
+			"host": "localhost",
+			"plugin": "cpu",
+			"plugin_instance": "0",
+			"type": "cpu",
+			"type_instance": "idle"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, []float64{2121}, metric.Values)
+		assert.Equal(t, []string{"derive"}, metric.Dstypes)
+		assert.Equal(t, []string{"samples"}, metric.Dsnames)
+		assert.Equal(t, float64(10), metric.Interval)
+		assert.Equal(t, "localhost", metric.Host)
+		assert.Equal(t, "cpu", metric.Plugin)
+		assert.Equal(t, "0", metric.PluginInstance)
+		assert.Equal(t, "cpu", metric.Type)
+		assert.Equal(t, "idle", metric.TypeInstance)
+	})
+
+	t.Run("parse multiple metrics", func(t *testing.T) {
+		input := []byte(`[
+			{
+				"values": [100],
+				"dstypes": ["derive"],
+				"dsnames": ["rx"],
+				"host": "host1",
+				"plugin": "interface",
+				"type": "if_octets"
+			},
+			{
+				"values": [200],
+				"dstypes": ["derive"],
+				"dsnames": ["tx"],
+				"host": "host1",
+				"plugin": "interface",
+				"type": "if_octets"
+			},
+			{
+				"values": [50],
+				"dstypes": ["gauge"],
+				"dsnames": ["value"],
+				"host": "host2",
+				"plugin": "cpu",
+				"type": "percent"
+			}
+		]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 3, len(*metrics))
+
+		assert.Equal(t, "interface", (*metrics)[0].Plugin)
+		assert.Equal(t, "interface", (*metrics)[1].Plugin)
+		assert.Equal(t, "cpu", (*metrics)[2].Plugin)
+		assert.Equal(t, float64(100), (*metrics)[0].Values[0])
+		assert.Equal(t, float64(200), (*metrics)[1].Values[0])
+		assert.Equal(t, float64(50), (*metrics)[2].Values[0])
+	})
+
+	t.Run("parse multi-dimensional metric", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [2112, 1001, 5555],
+			"dstypes": ["derive", "counter", "gauge"],
+			"dsnames": ["rx", "tx", "errors"],
+			"host": "localhost",
+			"plugin": "virt",
+			"type": "if_packets"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, 3, len(metric.Values))
+		assert.Equal(t, []float64{2112, 1001, 5555}, metric.Values)
+		assert.Equal(t, []string{"derive", "counter", "gauge"}, metric.Dstypes)
+		assert.Equal(t, []string{"rx", "tx", "errors"}, metric.Dsnames)
+	})
+
+	t.Run("parse metric without optional fields", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [42],
+			"dstypes": ["gauge"],
+			"dsnames": ["value"],
+			"host": "localhost",
+			"plugin": "memory",
+			"type": "memory"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, "", metric.PluginInstance)
+		assert.Equal(t, "", metric.TypeInstance)
+	})
+
+	t.Run("parse metric with time and interval", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [100],
+			"dstypes": ["derive"],
+			"dsnames": ["samples"],
+			"time": 1609459200.5,
+			"interval": 10.5,
+			"host": "localhost",
+			"plugin": "cpu",
+			"type": "cpu"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.NotNil(t, metric.Time)
+		assert.Equal(t, float64(10.5), metric.Interval)
+	})
+
+	t.Run("parse metric with metadata", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [100],
+			"dstypes": ["derive"],
+			"dsnames": ["samples"],
+			"host": "localhost",
+			"plugin": "cpu",
+			"type": "cpu",
+			"meta": {
+				"key1": "value1",
+				"key2": 123
+			}
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+	})
+
+	t.Run("error on invalid JSON", func(t *testing.T) {
+		input := []byte(`{invalid json}`)
+
+		metrics, err := ParseInputByte(input)
+		require.Error(t, err)
+		assert.Nil(t, metrics)
+	})
+
+	t.Run("error on non-array JSON", func(t *testing.T) {
+		input := []byte(`{"values": [100]}`)
+
+		metrics, err := ParseInputByte(input)
+		require.Error(t, err)
+		assert.Nil(t, metrics)
+	})
+
+	t.Run("parse empty array", func(t *testing.T) {
+		input := []byte(`[]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		assert.Equal(t, 0, len(*metrics))
+	})
+
+	t.Run("parse metric with all dstype variations", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [1, 2, 3, 4],
+			"dstypes": ["derive", "counter", "gauge", "absolute"],
+			"dsnames": ["d1", "d2", "d3", "d4"],
+			"host": "localhost",
+			"plugin": "test",
+			"type": "test"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, 4, len(metric.Values))
+		assert.Equal(t, []string{"derive", "counter", "gauge", "absolute"}, metric.Dstypes)
+	})
+
+	t.Run("parse real-world virt plugin data", func(t *testing.T) {
+		input := []byte(`[
+			{
+				"values": [1234.5, 5678.9],
+				"dstypes": ["derive", "counter"],
+				"dsnames": ["rx", "tx"],
+				"host": "controller-0.redhat.local",
+				"time": 1609459200,
+				"interval": 5,
+				"plugin": "virt",
+				"plugin_instance": "instance-00000001",
+				"type": "if_packets",
+				"type_instance": "tap73125d-60"
+			}
+		]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, 2, len(metric.Values))
+		assert.Equal(t, "controller-0.redhat.local", metric.Host)
+		assert.Equal(t, "virt", metric.Plugin)
+		assert.Equal(t, "instance-00000001", metric.PluginInstance)
+		assert.Equal(t, "if_packets", metric.Type)
+		assert.Equal(t, "tap73125d-60", metric.TypeInstance)
+		assert.Equal(t, []string{"rx", "tx"}, metric.Dsnames)
+	})
+
+	t.Run("parse metric with floating point values", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [123.456, 789.012],
+			"dstypes": ["gauge", "gauge"],
+			"dsnames": ["value1", "value2"],
+			"host": "localhost",
+			"plugin": "cpu",
+			"type": "percent"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.InDelta(t, 123.456, metric.Values[0], 0.001)
+		assert.InDelta(t, 789.012, metric.Values[1], 0.001)
+	})
+
+	t.Run("parse metric with zero values", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [0, 0, 0],
+			"dstypes": ["derive", "derive", "derive"],
+			"dsnames": ["a", "b", "c"],
+			"host": "localhost",
+			"plugin": "test",
+			"type": "test"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, []float64{0, 0, 0}, metric.Values)
+	})
+
+	t.Run("parse metric with negative values", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [-100, -50.5],
+			"dstypes": ["gauge", "gauge"],
+			"dsnames": ["temp", "pressure"],
+			"host": "localhost",
+			"plugin": "sensors",
+			"type": "temperature"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, float64(-100), metric.Values[0])
+		assert.Equal(t, float64(-50.5), metric.Values[1])
+	})
+
+	t.Run("parse metric with very large values", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [9999999999999, 1234567890123],
+			"dstypes": ["counter", "counter"],
+			"dsnames": ["bytes_in", "bytes_out"],
+			"host": "localhost",
+			"plugin": "interface",
+			"type": "if_octets"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, float64(9999999999999), metric.Values[0])
+		assert.Equal(t, float64(1234567890123), metric.Values[1])
+	})
+
+	t.Run("parse metric with special characters in strings", func(t *testing.T) {
+		input := []byte(`[{
+			"values": [100],
+			"dstypes": ["gauge"],
+			"dsnames": ["value"],
+			"host": "host-name.with-dashes",
+			"plugin": "plugin_with_underscores",
+			"plugin_instance": "instance.0",
+			"type": "type-name",
+			"type_instance": "instance_name"
+		}]`)
+
+		metrics, err := ParseInputByte(input)
+		require.NoError(t, err)
+		require.NotNil(t, metrics)
+		require.Equal(t, 1, len(*metrics))
+
+		metric := (*metrics)[0]
+		assert.Equal(t, "host-name.with-dashes", metric.Host)
+		assert.Equal(t, "plugin_with_underscores", metric.Plugin)
+		assert.Equal(t, "instance.0", metric.PluginInstance)
+		assert.Equal(t, "type-name", metric.Type)
+		assert.Equal(t, "instance_name", metric.TypeInstance)
+	})
+}

--- a/plugins/handler/sensubility-metrics/pkg/sensu/sensu_test.go
+++ b/plugins/handler/sensubility-metrics/pkg/sensu/sensu_test.go
@@ -1,0 +1,480 @@
+package sensu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMsgValid(t *testing.T) {
+	t.Run("valid message with all required fields", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels: Labels{
+				Client:   "test-client",
+				Check:    "test-check",
+				Severity: "warning",
+			},
+			Annotations: Annotations{
+				Command: "test-command",
+				Output:  "test output",
+			},
+		}
+
+		assert.True(t, IsMsgValid(msg))
+	})
+
+	t.Run("valid message with minimal required fields", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels: Labels{
+				Client: "test-client",
+			},
+		}
+
+		assert.True(t, IsMsgValid(msg))
+	})
+
+	t.Run("invalid message with missing StartsAt", func(t *testing.T) {
+		msg := Message{
+			Labels: Labels{
+				Client: "test-client",
+			},
+		}
+
+		assert.False(t, IsMsgValid(msg))
+	})
+
+	t.Run("invalid message with empty StartsAt", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "",
+			Labels: Labels{
+				Client: "test-client",
+			},
+		}
+
+		assert.False(t, IsMsgValid(msg))
+	})
+
+	t.Run("invalid message with missing Client", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels:   Labels{},
+		}
+
+		assert.False(t, IsMsgValid(msg))
+	})
+
+	t.Run("invalid message with empty Client", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels: Labels{
+				Client: "",
+			},
+		}
+
+		assert.False(t, IsMsgValid(msg))
+	})
+
+	t.Run("invalid message with both fields missing", func(t *testing.T) {
+		msg := Message{}
+
+		assert.False(t, IsMsgValid(msg))
+	})
+
+	t.Run("valid message with optional fields", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels: Labels{
+				Client:   "test-client",
+				Check:    "disk-usage",
+				Severity: "critical",
+			},
+			Annotations: Annotations{
+				Command:  "/usr/bin/check_disk",
+				Issued:   1234567890,
+				Executed: 1234567891,
+				Duration: 1.5,
+				Output:   "CRITICAL - disk usage at 95%",
+				Status:   2,
+				StartsAt: "2023-01-01T00:00:00Z",
+			},
+		}
+
+		assert.True(t, IsMsgValid(msg))
+	})
+}
+
+func TestIsOutputValid(t *testing.T) {
+	t.Run("valid output with single service", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service:   "test-service",
+				Container: "test-container",
+				Status:    "running",
+				Healthy:   1.0,
+			},
+		}
+
+		assert.True(t, IsOutputValid(outputs))
+	})
+
+	t.Run("valid output with multiple services", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service:   "service1",
+				Container: "container1",
+				Status:    "running",
+				Healthy:   1.0,
+			},
+			{
+				Service:   "service2",
+				Container: "container2",
+				Status:    "stopped",
+				Healthy:   0.0,
+			},
+			{
+				Service:   "service3",
+				Container: "container3",
+				Status:    "running",
+				Healthy:   1.0,
+			},
+		}
+
+		assert.True(t, IsOutputValid(outputs))
+	})
+
+	t.Run("valid output with minimal fields", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service: "minimal-service",
+			},
+		}
+
+		assert.True(t, IsOutputValid(outputs))
+	})
+
+	t.Run("invalid output with missing service", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Container: "test-container",
+				Status:    "running",
+				Healthy:   1.0,
+			},
+		}
+
+		assert.False(t, IsOutputValid(outputs))
+	})
+
+	t.Run("invalid output with empty service", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service:   "",
+				Container: "test-container",
+			},
+		}
+
+		assert.False(t, IsOutputValid(outputs))
+	})
+
+	t.Run("invalid output with one valid and one invalid", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service:   "valid-service",
+				Container: "container1",
+			},
+			{
+				Service:   "",
+				Container: "container2",
+			},
+		}
+
+		assert.False(t, IsOutputValid(outputs))
+	})
+
+	t.Run("valid empty output array", func(t *testing.T) {
+		outputs := HealthCheckOutput{}
+
+		assert.True(t, IsOutputValid(outputs))
+	})
+
+	t.Run("invalid output with missing service in middle", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service: "service1",
+			},
+			{
+				Service: "",
+			},
+			{
+				Service: "service3",
+			},
+		}
+
+		assert.False(t, IsOutputValid(outputs))
+	})
+}
+
+func TestBuildMsgErr(t *testing.T) {
+	t.Run("error with missing StartsAt", func(t *testing.T) {
+		msg := Message{
+			Labels: Labels{
+				Client: "test-client",
+			},
+		}
+
+		err := BuildMsgErr(msg)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Contains(t, eMF.Fields, "startsAt")
+		assert.NotContains(t, eMF.Fields, "labels.client")
+		assert.Contains(t, err.Error(), "startsAt")
+	})
+
+	t.Run("error with missing Client", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+		}
+
+		err := BuildMsgErr(msg)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Contains(t, eMF.Fields, "labels.client")
+		assert.NotContains(t, eMF.Fields, "startsAt")
+		assert.Contains(t, err.Error(), "labels.client")
+	})
+
+	t.Run("error with both fields missing", func(t *testing.T) {
+		msg := Message{}
+
+		err := BuildMsgErr(msg)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Contains(t, eMF.Fields, "startsAt")
+		assert.Contains(t, eMF.Fields, "labels.client")
+		assert.Contains(t, err.Error(), "startsAt")
+		assert.Contains(t, err.Error(), "labels.client")
+		assert.Contains(t, err.Error(), "missing fields in received data")
+	})
+
+	t.Run("error with valid message returns empty error", func(t *testing.T) {
+		msg := Message{
+			StartsAt: "2023-01-01T00:00:00Z",
+			Labels: Labels{
+				Client: "test-client",
+			},
+		}
+
+		err := BuildMsgErr(msg)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Empty(t, eMF.Fields)
+	})
+
+	t.Run("error message format", func(t *testing.T) {
+		msg := Message{}
+
+		err := BuildMsgErr(msg)
+		require.NotNil(t, err)
+
+		errorMsg := err.Error()
+		assert.Contains(t, errorMsg, "missing fields in received data")
+		assert.Contains(t, errorMsg, "(")
+		assert.Contains(t, errorMsg, ")")
+	})
+}
+
+func TestBuildOutputsErr(t *testing.T) {
+	t.Run("error with single missing service", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Container: "test-container",
+			},
+		}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Contains(t, eMF.Fields, "annotations.output[0].service")
+		assert.Contains(t, err.Error(), "annotations.output[0].service")
+	})
+
+	t.Run("error with multiple missing services", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Container: "container1",
+			},
+			{
+				Service: "valid-service",
+			},
+			{
+				Container: "container3",
+			},
+		}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Contains(t, eMF.Fields, "annotations.output[0].service")
+		assert.Contains(t, eMF.Fields, "annotations.output[2].service")
+		assert.NotContains(t, eMF.Fields, "annotations.output[1].service")
+	})
+
+	t.Run("error with all services missing", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Container: "container1",
+			},
+			{
+				Container: "container2",
+			},
+			{
+				Container: "container3",
+			},
+		}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Len(t, eMF.Fields, 3)
+		assert.Contains(t, eMF.Fields, "annotations.output[0].service")
+		assert.Contains(t, eMF.Fields, "annotations.output[1].service")
+		assert.Contains(t, eMF.Fields, "annotations.output[2].service")
+	})
+
+	t.Run("error with valid outputs returns empty error", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{
+				Service:   "service1",
+				Container: "container1",
+			},
+			{
+				Service:   "service2",
+				Container: "container2",
+			},
+		}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Empty(t, eMF.Fields)
+	})
+
+	t.Run("error with empty outputs array", func(t *testing.T) {
+		outputs := HealthCheckOutput{}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		eMF, ok := err.(*ErrMissingFields)
+		require.True(t, ok)
+		assert.Empty(t, eMF.Fields)
+	})
+
+	t.Run("error index format in message", func(t *testing.T) {
+		outputs := HealthCheckOutput{
+			{},
+			{},
+			{},
+		}
+
+		err := BuildOutputsErr(outputs)
+		require.NotNil(t, err)
+
+		errorMsg := err.Error()
+		assert.Contains(t, errorMsg, "[0]")
+		assert.Contains(t, errorMsg, "[1]")
+		assert.Contains(t, errorMsg, "[2]")
+	})
+}
+
+func TestErrMissingFields(t *testing.T) {
+	t.Run("error message with single field", func(t *testing.T) {
+		err := &ErrMissingFields{
+			Fields: []string{"field1"},
+		}
+
+		assert.Equal(t, "missing fields in received data (field1)", err.Error())
+	})
+
+	t.Run("error message with multiple fields", func(t *testing.T) {
+		err := &ErrMissingFields{
+			Fields: []string{"field1", "field2", "field3"},
+		}
+
+		errorMsg := err.Error()
+		assert.Contains(t, errorMsg, "missing fields in received data")
+		assert.Contains(t, errorMsg, "field1")
+		assert.Contains(t, errorMsg, "field2")
+		assert.Contains(t, errorMsg, "field3")
+		assert.Contains(t, errorMsg, ", ")
+	})
+
+	t.Run("error message with empty fields", func(t *testing.T) {
+		err := &ErrMissingFields{
+			Fields: []string{},
+		}
+
+		assert.Equal(t, "missing fields in received data ()", err.Error())
+	})
+
+	t.Run("add missing field", func(t *testing.T) {
+		err := &ErrMissingFields{
+			Fields: []string{},
+		}
+
+		err.addMissingField("field1")
+		assert.Contains(t, err.Fields, "field1")
+		assert.Len(t, err.Fields, 1)
+
+		err.addMissingField("field2")
+		assert.Contains(t, err.Fields, "field1")
+		assert.Contains(t, err.Fields, "field2")
+		assert.Len(t, err.Fields, 2)
+	})
+
+	t.Run("add multiple missing fields", func(t *testing.T) {
+		err := &ErrMissingFields{}
+
+		err.addMissingField("field1")
+		err.addMissingField("field2")
+		err.addMissingField("field3")
+
+		assert.Len(t, err.Fields, 3)
+		assert.Equal(t, "field1", err.Fields[0])
+		assert.Equal(t, "field2", err.Fields[1])
+		assert.Equal(t, "field3", err.Fields[2])
+	})
+
+	t.Run("error message format with long field names", func(t *testing.T) {
+		err := &ErrMissingFields{
+			Fields: []string{
+				"annotations.output[0].service",
+				"annotations.output[1].service",
+				"labels.client",
+			},
+		}
+
+		errorMsg := err.Error()
+		assert.Contains(t, errorMsg, "annotations.output[0].service")
+		assert.Contains(t, errorMsg, "annotations.output[1].service")
+		assert.Contains(t, errorMsg, "labels.client")
+	})
+}


### PR DESCRIPTION
Ceilometer:
- ParseInputJSON with various message formats
- ParseInputMsgPack for msgpack parsing
- sanitize function with escaped quotes and payload formatting
- Error handling for invalid JSON and malformed data
- Edge cases: empty payloads, multiple metrics, user metadata

Collectd:
- ParseInputByte for all metric variations
- Multi-dimensional metrics with multiple values
- Optional fields (plugin_instance, type_instance)
- Error handling for invalid JSON and non-array data
- Edge cases: empty arrays, zero values, negative values, large values
- Real-world virt plugin data formats

Sensu:
- IsMsgValid: validation with all required/optional fields, missing fields
- IsOutputValid: single/multiple services, empty arrays, invalid outputs
- BuildMsgErr: error building for missing message fields
- BuildOutputsErr: error building for missing output fields with indices
- ErrMissingFields: error type testing, message formatting, field addition
