### PR TITLE
Use HTTPS and enable GPG verification for opstools repo

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,8 @@ COPY . $D/
 # dependencies for qpid-proton-c
 COPY build/repos/opstools.repo /etc/yum.repos.d/CentOS-OpsTools.repo
 
-RUN dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
+RUN rpm --import https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools && \
+    dnf install golang git qpid-proton-c-devel -y --setopt=tsflags=nodocs
 RUN go install golang.org/dl/go1.25.9@latest && /go/bin/go1.25.9 download && PRODUCTION_BUILD=false CONTAINER_BUILD=true GOCMD=/go/bin/go1.25.9 ./build.sh
 
 # --- end build, create smart gateway layer ---

--- a/build/repos/opstools.repo
+++ b/build/repos/opstools.repo
@@ -2,7 +2,8 @@
 
 [centos9-opstools]
 name=centos9-opstools
-baseurl=http://mirror.stream.centos.org/SIGs/9-stream/opstools/$basearch/collectd-5/
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/opstools/$basearch/collectd-5/
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools
 module_hotfixes=1


### PR DESCRIPTION
Switch CentOS OpsTools repository from plain HTTP to HTTPS and enable GPG signature verification to prevent supply chain attacks during container builds.

Related-To: OSPRH-33317