### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,6 @@
 name: Integration testing
+permissions:
+  contents: read
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
   OPSTOOLS_REPO: https://raw.githubusercontent.com/infrawatch/sg-core/0d28a1c2f87bd64f2d67effcda926855af057a82/build/repos/opstools.repo
@@ -25,7 +27,7 @@ jobs:
       PROMETHEUS_IMAGE: quay.io/prometheus/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Remove currently installed mysql and postgresql
         run: |
@@ -119,7 +121,7 @@ jobs:
       PROMETHEUS_IMAGE: quay.io/prometheus/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Remove currently installed mysql and postgresql
         run: |
@@ -224,7 +226,7 @@ jobs:
       PROMETHEUS_IMAGE: quay.io/prometheus/prometheus:latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
       - name: Remove currently installed mysql and postgresql
         run: |
@@ -308,7 +310,7 @@ jobs:
       RSYSLOG_VOLUME: "--volume ${{ github.workspace }}/ci/service_configs/rsyslog/rsyslog_config.conf:/etc/rsyslog.d/integration.conf:z"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       # start data store services
       - name: Start Elasticsearch service
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 env:
   PROJECT_ROOT: /root/go/src/github.com/infrawatch/sg-core
   OPSTOOLS_REPO: https://raw.githubusercontent.com/infrawatch/sg-core/0d28a1c2f87bd64f2d67effcda926855af057a82/build/repos/opstools.repo
@@ -20,14 +22,14 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25.9'
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       #- name: download libraries
       #  run: go mod download
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.0
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           # Caching conflicts happen in GHA, so just disable for now
           skip-cache: true
@@ -38,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       # start services
       - name: Start Elasticsearch service
         run: |
@@ -67,15 +69,15 @@ jobs:
             --volume ${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT \
             $TEST_IMAGE bash $PROJECT_ROOT/ci/unit/run_tests.sh
       - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1.8.0
+        uses: shogo82148/actions-goveralls@7b1bd2871942af030d707d6574e5f684f9891fb2 # v1.8.0
         with:
           path-to-profile: ${{ github.workspace }}/profile.cov
   image-build:
     name: Image build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.3
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25.9'
       - name: Verify image builds

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
     steps:
       - name: update PR with coveralls badge
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin all third-party action references to full 40-character commit SHAs to prevent supply-chain attacks via mutable tag retargeting. Add least-privilege `permissions: contents: read` to integration and CI workflows.

Related-To: OSPRH-33320

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>