### PR TITLE
Add govulncheck job to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,18 @@ env:
 on: [push, pull_request]
 
 jobs:
+  govulncheck:
+    name: Vulnerability check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.25.9'
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+      - name: Run govulncheck
+        run: govulncheck ./...
   golangci:
     name: Linting
     runs-on: ubuntu-latest


### PR DESCRIPTION
Runs golang.org/x/vuln/cmd/govulncheck against the module graph on every push and pull request to catch known CVEs in dependencies early.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>