### PR TITLE
Run containers as non-root user; add pod security context

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,4 +23,7 @@ LABEL io.k8s.display-name="Smart Gateway" \
 COPY --from=builder /tmp/sg-core /
 COPY --from=builder /tmp/plugins/*.so /usr/lib64/sg-core/
 
+RUN echo "sg:x:1001:0:sg user:/:/sbin/nologin" >> /etc/passwd
+USER 1001
+
 ENTRYPOINT ["/sg-core"]

--- a/deploy/sg-core-pod-security.yaml
+++ b/deploy/sg-core-pod-security.yaml
@@ -1,0 +1,39 @@
+# Reference-only securityContext for sg-core container deployments.
+# This file is not consumed by any automation. The smart-gateway-operator
+# already applies these settings during reconciliation.
+# Use this as a guide when deploying sg-core outside the operator
+# (vanilla Kubernetes, manual podman, etc.).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sg-core
+  labels:
+    app: sg-core
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: sg-core
+      image: quay.io/infrawatch/sg-core:latest
+      args: ["-config", "/etc/sg-core/sg-core.conf.yaml"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: socket-dir
+          mountPath: /tmp
+        - name: sg-core-config
+          mountPath: /etc/sg-core
+          readOnly: true
+  volumes:
+    - name: socket-dir
+      emptyDir: {}
+    - name: sg-core-config
+      configMap:
+        name: sg-core-config

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -7,7 +7,7 @@ COPY . $D/
 RUN dnf install -y gcc make qpid-proton-c-devel
 RUN make && mv gen /gen
 
+RUN echo "sg:x:1001:0:sg user:/:/sbin/nologin" >> /etc/passwd
+USER 1001
 
 ENTRYPOINT ["/gen"]
-
-


### PR DESCRIPTION
Set USER 1001 in build and generator Dockerfiles to follow container best practices. Add reference Pod securityContext manifest under deploy/.

Related-To: OSPRH-33322